### PR TITLE
Remove all references to "data_files" string in code

### DIFF
--- a/benchmark_problems/README.md
+++ b/benchmark_problems/README.md
@@ -8,4 +8,4 @@ Two problem definition file formats are supported:
 * The format native to FitBenchmarking (denoted FitBenchmark). For example, see the neutron_data folder.
 * NIST Noninear Regression [format](https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/Misra1a.dat). For example, see the NIST folder.
 
-All FitBenchmark data files are recommended be stored under a folder named `data_files` inside their corresponding problem folders (e.g. `Muon_data`, `Neutron_data`, etc.)
+A data file name specified within FitBenchmark definition file is recommended to be stored in a sub-folder named `data_files` relative to the location of the definition file.

--- a/benchmark_problems/README.md
+++ b/benchmark_problems/README.md
@@ -7,3 +7,5 @@ Two problem definition file formats are supported:
 
 * The format native to FitBenchmarking (denoted FitBenchmark). For example, see the neutron_data folder.
 * NIST Noninear Regression [format](https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/Misra1a.dat). For example, see the NIST folder.
+
+All FitBenchmark data files should be stored under the folder `data_files` inside their corresponding problem folders (e.g. `Muon_data`, `Neutron_data`, etc.)

--- a/benchmark_problems/README.md
+++ b/benchmark_problems/README.md
@@ -8,4 +8,4 @@ Two problem definition file formats are supported:
 * The format native to FitBenchmarking (denoted FitBenchmark). For example, see the neutron_data folder.
 * NIST Noninear Regression [format](https://www.itl.nist.gov/div898/strd/nls/data/LINKS/DATA/Misra1a.dat). For example, see the NIST folder.
 
-All FitBenchmark data files should be stored under the folder `data_files` inside their corresponding problem folders (e.g. `Muon_data`, `Neutron_data`, etc.)
+All FitBenchmark data files are recommended be stored under a folder named `data_files` inside their corresponding problem folders (e.g. `Muon_data`, `Neutron_data`, etc.)

--- a/example_scripts/example_runScripts.py
+++ b/example_scripts/example_runScripts.py
@@ -93,7 +93,8 @@ color_scale = [(1.1, 'ranking-top-1'),
 # Do this, in this example file, by selecting sub-folders in benchmark_probs_dir
 # "Muon_data" works for mantid minimizers
 # problem_sets = ["Neutron_data", "NIST/average_difficulty"]
-problem_sets = ["CUTEst", "Muon_data", "Neutron_data", "NIST/average_difficulty", "NIST/high_difficulty", "NIST/low_difficulty"]
+# problem_sets = ["CUTEst", "Muon_data", "Neutron_data", "NIST/average_difficulty", "NIST/high_difficulty", "NIST/low_difficulty"]
+problem_sets = ["Muon_data"]
 for sub_dir in problem_sets:
   # generate group label/name used for problem set
   label = sub_dir.replace('/', '_')

--- a/example_scripts/example_runScripts.py
+++ b/example_scripts/example_runScripts.py
@@ -93,8 +93,7 @@ color_scale = [(1.1, 'ranking-top-1'),
 # Do this, in this example file, by selecting sub-folders in benchmark_probs_dir
 # "Muon_data" works for mantid minimizers
 # problem_sets = ["Neutron_data", "NIST/average_difficulty"]
-# problem_sets = ["CUTEst", "Muon_data", "Neutron_data", "NIST/average_difficulty", "NIST/high_difficulty", "NIST/low_difficulty"]
-problem_sets = ["CUTEst"]
+problem_sets = ["CUTEst", "Muon_data", "Neutron_data", "NIST/average_difficulty", "NIST/high_difficulty", "NIST/low_difficulty"]
 for sub_dir in problem_sets:
   # generate group label/name used for problem set
   label = sub_dir.replace('/', '_')

--- a/example_scripts/example_runScripts.py
+++ b/example_scripts/example_runScripts.py
@@ -94,8 +94,8 @@ color_scale = [(1.1, 'ranking-top-1'),
 # Do this, in this example file, by selecting sub-folders in benchmark_probs_dir
 # "Muon_data" works for mantid minimizers
 # problem_sets = ["Neutron_data", "NIST/average_difficulty"]
-# problem_sets = ["CUTEst", "Muon_data", "Neutron_data", "NIST/average_difficulty", "NIST/high_difficulty", "NIST/low_difficulty"]
-problem_sets = ["Muon_data"]
+problem_sets = ["CUTEst", "Muon_data", "Neutron_data", "NIST/average_difficulty", "NIST/high_difficulty", "NIST/low_difficulty"]
+# problem_sets = ["Muon_data"]
 for sub_dir in problem_sets:
   # generate group label/name used for problem set
   label = sub_dir.replace('/', '_')

--- a/fitbenchmarking/parsing/parse_fitbenchmark_data.py
+++ b/fitbenchmarking/parsing/parse_fitbenchmark_data.py
@@ -64,24 +64,26 @@ class FittingProblem(base_fitting_problem.BaseFittingProblem):
 
         super(FittingProblem, self).close_file()
 
-    def get_data_file(self, fname, input_file):
+    def get_data_file(self, full_path_of_fitting_def_file, data_file_name):
         """
-        Gets the path to the fitbenchmark problem data_file used in the problem.
+        Find/create the (full) path to a data_file specified in a fitbenchmark definition file, where
+        the data_file is search for in the directory of the definition file and subfolders of this 
+        definition
 
-        @param fname :: path to the problem definition file
-        @param input_file :: file name of the data file
+        @param full_path_of_fitting_def_file :: (full) path of a FitBenchmark definition file
+        @param data_file_name :: the name of the data file as specified in the FitBenchmark definition file
 
-        @returns :: path to the data files directory (str)
+        @returns :: (full) path to a data file (str). Return None if not found
         """
         data_file = None
-        #find path of the folder containing data files
-        for root, dirs, files in os.walk(os.path.dirname(fname)):
+        # find or search for path for data_file_name
+        for root, dirs, files in os.walk(os.path.dirname(full_path_of_fitting_def_file)):
             for name in files:
-                if input_file == name:
-                    data_file = os.path.join(root, input_file)
+                if data_file_name == name:
+                    data_file = os.path.join(root, data_file_name)
 
         if data_file == None:
-            logger.error("Data file {0} not found".format(input_file))
+            logger.error("Data file {0} not found".format(data_file_name))
 
         return data_file
 

--- a/fitbenchmarking/parsing/parse_fitbenchmark_data.py
+++ b/fitbenchmarking/parsing/parse_fitbenchmark_data.py
@@ -76,12 +76,15 @@ class FittingProblem(base_fitting_problem.BaseFittingProblem):
 
         @returns :: path to the data files directory (str)
         """
-
+        data_file = None
         #find path of the folder containing data files
-        [x[0] for x in os.walk(os.path.dirname(fname))]
-        dirpath = x[0]
+        for root, dirs, files in os.walk(os.path.dirname(fname)):
+            for name in files:
+                if input_file == name:
+                    data_file = os.path.join(root, input_file)
 
-        data_file = os.path.join(dirpath, input_file)
+        if data_file == None:
+            logger.error("Data file {0} not found".format(input_file))
 
         return data_file
 

--- a/fitbenchmarking/parsing/parse_fitbenchmark_data.py
+++ b/fitbenchmarking/parsing/parse_fitbenchmark_data.py
@@ -72,12 +72,12 @@ class FittingProblem(base_fitting_problem.BaseFittingProblem):
         Gets the path to the fitbenchmark problem data_file used in the problem.
 
         @param fname :: path to the problem definition file
-        @param dirpath :: path of the folder containing data files
         @param input_file :: file name of the data file
 
         @returns :: path to the data files directory (str)
         """
 
+        #find path of the folder containing data files
         [x[0] for x in os.walk(os.path.dirname(fname))]
         dirpath = x[0]
 

--- a/fitbenchmarking/parsing/parse_fitbenchmark_data.py
+++ b/fitbenchmarking/parsing/parse_fitbenchmark_data.py
@@ -70,22 +70,18 @@ class FittingProblem(base_fitting_problem.BaseFittingProblem):
     def get_data_file(self, fname, input_file):
         """
         Gets the path to the fitbenchmark problem data_file used in the problem.
-        sep_idx is used to find the last separator in the problem file path
-        and set up the path for the data_files folder i.e truncates the path
-        to ../Neutron_data and adds ../Neutron_data/data_files
 
         @param fname :: path to the problem definition file
+        @param dirpath :: path of the folder containing data files
         @param input_file :: file name of the data file
 
         @returns :: path to the data files directory (str)
         """
 
-        prefix = ""
-        if os.sep in fname:
-            sep_idx = fname.rfind(os.sep)
-            prefix = os.path.join(fname[:sep_idx], "data_files")
+        [x[0] for x in os.walk(os.path.dirname(fname))]
+        dirpath = x[0]
 
-        data_file = os.path.join(prefix, input_file)
+        data_file = os.path.join(dirpath, input_file)
 
         return data_file
 

--- a/fitbenchmarking/parsing/parse_fitbenchmark_data.py
+++ b/fitbenchmarking/parsing/parse_fitbenchmark_data.py
@@ -66,9 +66,9 @@ class FittingProblem(base_fitting_problem.BaseFittingProblem):
 
     def get_data_file(self, full_path_of_fitting_def_file, data_file_name):
         """
-        Find/create the (full) path to a data_file specified in a fitbenchmark definition file, where
+        Find/create the (full) path to a data_file specified in a FitBenchmark definition file, where
         the data_file is search for in the directory of the definition file and subfolders of this 
-        definition
+        file
 
         @param full_path_of_fitting_def_file :: (full) path of a FitBenchmark definition file
         @param data_file_name :: the name of the data file as specified in the FitBenchmark definition file


### PR DESCRIPTION
Reimplement the function `get_data_file` in `parse_fitbenchmark_data.py` to use os.walk to find the right directory for the data files.

Also update README in benchmark_problems accordingly

#### Description of Work

Fixes #158 

#### Testing Instructions

1. Run `example_runScripts.py` with problems type FitBenchmark
2. Try renaming the folder containing FitBenchmarking data files (currently named data_files) which is under the folders benchmark_problems/Muon_data and benchmark_problems/Neutron_data 