### PR TITLE
Issue #134: Add option to options file for displaying absolute value,…

### DIFF
--- a/example_scripts/example_runScripts.py
+++ b/example_scripts/example_runScripts.py
@@ -37,15 +37,16 @@ custom_minimizers = None
 
 # SPECIFY THE MINIMIZERS YOU WANT TO BENCHMARK, AND AS A MINIMUM FOR THE SOFTWARE YOU SPECIFIED ABOVE
 if len(sys.argv) > 1:
-  # Read custom minimizer options from file
-  software_options['minimizer_options'] = current_path + sys.argv[1]
+    # Read custom minimizer options from file
+    software_options['minimizer_options'] = None
+    software_options['options_file'] = current_path + sys.argv[1]
 elif custom_minimizers:
-  # Custom minimizer options:
-  software_options['minimizer_options'] = custom_minimizers
+    # Custom minimizer options:
+    software_options['minimizer_options'] = custom_minimizers
 else:
-  # Using default minimizers from
-  # fitbenchmarking/fitbenchmarking/fitbenchmarking_default_options.json
-  software_options['minimizer_options'] = None
+    # Using default minimizers from
+    # fitbenchmarking/fitbenchmarking/fitbenchmarking_default_options.json
+    software_options['minimizer_options'] = None
 
 # Benchmark problem directories
 benchmark_probs_dir = os.path.join(fitbenchmarking_folder,
@@ -94,14 +95,14 @@ for sub_dir in problem_sets:
 
     print('\nRunning the benchmarking on the {} problem set\n'.format(label))
     results_per_group, results_dir = fitBenchmarking(group_name=label, software_options=software_options,
-                                                   data_dir=data_dir,
-                                                   use_errors=use_errors, results_dir=results_dir)
+                                                     data_dir=data_dir,
+                                                     use_errors=use_errors, results_dir=results_dir)
 
     print('\nProducing output for the {} problem set\n'.format(label))
     for idx, group_results in enumerate(results_per_group):
         # Display the runtime and accuracy results in a table
         printTables(software_options, group_results,
-                group_name=label, use_errors=use_errors,
-                color_scale=color_scale, results_dir=results_dir)
+                    group_name=label, use_errors=use_errors,
+                    color_scale=color_scale, results_dir=results_dir)
 
     print('\nCompleted benchmarking for {} problem set\n'.format(sub_dir))

--- a/example_scripts/example_runScripts_SasView.py
+++ b/example_scripts/example_runScripts_SasView.py
@@ -64,7 +64,8 @@ custom_minimizers = {"mantid": ["BFGS", "Simplex"],
 # SPECIFY THE MINIMIZERS YOU WANT TO BENCHMARK, AND AS A MINIMUM FOR THE SOFTWARE YOU SPECIFIED ABOVE
 if len(sys.argv) > 1:
   # Read custom minimizer options from file
-  software_options['minimizer_options'] = current_path + sys.argv[1]
+  software_options['minimizer_options'] = None
+  software_options['options_file'] = current_path + sys.argv[1]
 elif custom_minimizers:
   # Custom minimizer options:
   software_options['minimizer_options'] = custom_minimizers
@@ -72,7 +73,6 @@ else:
   # Using default minimizers from
   # fitbenchmarking/fitbenchmarking/fitbenchmarking_default_options.json
   software_options['minimizer_options'] = None
-
 
 # Benchmark problem directories
 benchmark_probs_dir = os.path.join(fitbenchmarking_folder,

--- a/example_scripts/example_runScripts_expert.py
+++ b/example_scripts/example_runScripts_expert.py
@@ -43,7 +43,8 @@ custom_minimizers = None
 # SPECIFY THE MINIMIZERS YOU WANT TO BENCHMARK, AND AS A MINIMUM FOR THE SOFTWARE YOU SPECIFIED ABOVE
 if len(sys.argv) > 1:
     # Read custom minimizer options from file
-    software_options['minimizer_options'] = current_path + sys.argv[1]
+    software_options['minimizer_options'] = None
+    software_options['options_file'] = current_path + sys.argv[1]
 elif custom_minimizers:
     # Custom minimizer options:
     software_options['minimizer_options'] = custom_minimizers

--- a/example_scripts/example_runScripts_mantid.py
+++ b/example_scripts/example_runScripts_mantid.py
@@ -49,7 +49,8 @@ custom_minimizers = {"mantid": ["Simplex"],
 # SPECIFY THE MINIMIZERS YOU WANT TO BENCHMARK, AND AS A MINIMUM FOR THE SOFTWARE YOU SPECIFIED ABOVE
 if len(sys.argv) > 1:
   # Read custom minimizer options from file
-  software_options['minimizer_options'] = current_path + sys.argv[1]
+  software_options['minimizer_options'] = None
+  software_options['options_file'] = current_path + sys.argv[1]
 elif custom_minimizers:
   # Custom minimizer options:
   software_options['minimizer_options'] = custom_minimizers

--- a/fitbenchmarking/fitbenchmarking_default_options.json
+++ b/fitbenchmarking/fitbenchmarking_default_options.json
@@ -1,5 +1,5 @@
 {
-    "minimizers": {
+    "minimizers" : {
         "mantid" : ["BFGS", "Conjugate gradient (Fletcher-Reeves imp.)",
                     "Conjugate gradient (Polak-Ribiere imp.)",
                     "Damped GaussNewton",
@@ -8,5 +8,7 @@
                     "Trust Region"],
         "scipy" : ["lm", "trf", "dogbox"],
         "sasview" : ["amoeba", "lm", "newton", "de", "pt", "mp"]
-        }
+        },
+
+    "comparison_mode" : "both" 
 }

--- a/fitbenchmarking/resproc/numpy_restables.py
+++ b/fitbenchmarking/resproc/numpy_restables.py
@@ -77,29 +77,62 @@ def create_norm_tbls(accuracy_tbl, time_tbl):
     return norm_acc_rankings, norm_runtimes,
 
 
-def create_summary_tbls(norm_acc_rankings, norm_runtimes):
+def create_summary_tbls(acc_rankings, runtimes):
     """
     Creates summary tables of the obtained results, i.e. the minimum
     maximum, mean and median of each column in the normalised numpy
     arrays.
 
-    @param norm_acc_rankings :: the normalised accuracy results numpy array
-    @param norm_runtimes :: the normalised runtime results numpy array
+    @param acc_rankings :: the combined accuracy results numpy array
+    @param runtimes :: the combined runtime results numpy array
 
     @returns :: the summary tables for both runtime and accuracy
     """
+    acc_rankings = acc_rankings[:, :, 1]
+    runtimes = runtimes[:, :, 1]
 
-    summary_cells_acc = np.array([np.nanmin(norm_acc_rankings, 0),
-                                  np.nanmax(norm_acc_rankings, 0),
-                                  nanmean(norm_acc_rankings, 0),
-                                  nanmedian(norm_acc_rankings, 0)])
+    summary_cells_acc = np.array([np.nanmin(acc_rankings, 0),
+                                  np.nanmax(acc_rankings, 0),
+                                  nanmean(acc_rankings, 0),
+                                  nanmedian(acc_rankings, 0)])
 
-    summary_cells_runtime = np.array([np.nanmin(norm_runtimes, 0),
-                                      np.nanmax(norm_runtimes, 0),
-                                      nanmean(norm_runtimes, 0),
-                                      nanmedian(norm_runtimes, 0)])
+    summary_cells_runtime = np.array([np.nanmin(runtimes, 0),
+                                      np.nanmax(runtimes, 0),
+                                      nanmean(runtimes, 0),
+                                      nanmedian(runtimes, 0)])
 
     return summary_cells_acc, summary_cells_runtime
+
+
+def create_combined_tbls(abs_accuracy, rel_accuracy, abs_runtime, rel_runtime):
+    """
+    Create a table that holds both absolute and relative information on
+    each result.
+
+    @param abs_accuracy :: The table with the absolute accuracy reported
+    @param rel_accuracy :: The table with the relative accuracy reported
+    @param abs_runtime :: The table with the absolute runtime reported
+    @param rel_runtime :: The table with the relative runtime reported
+
+    @returns :: combined_accuracy and combined_runtime tables with both
+                values present in each cell.
+                e.g. combined_accuracy[2,3,0] == rel_accuracy[2,3]
+                     combined_accuracy[2,3,1] == abs_accuracy[2,3]
+    """
+
+    accuracy_shape = (abs_accuracy.shape[0], abs_accuracy.shape[1], 2)
+    runtime_shape = (abs_runtime.shape[0], abs_runtime.shape[1], 2)
+
+    combined_accuracy = np.zeros(accuracy_shape)
+    combined_runtime = np.zeros(runtime_shape)
+
+    combined_accuracy[:, :, 0] = abs_accuracy
+    combined_accuracy[:, :, 1] = rel_accuracy
+
+    combined_runtime[:, :, 0] = abs_runtime
+    combined_runtime[:, :, 1] = rel_runtime
+
+    return combined_accuracy, combined_runtime
 
 
 def init_numpy_tbls(results_per_test, minimizers):

--- a/fitbenchmarking/resproc/rst_table.py
+++ b/fitbenchmarking/resproc/rst_table.py
@@ -37,7 +37,7 @@ SCRIPT_DIR = os.path.dirname(__file__)
 
 
 def create(columns_txt, rows_txt, cells, comparison_type, comparison_dim,
-           using_errors, color_scale=None):
+           using_errors, color_scale=None, comparison_mode='abs'):
     """
     Creates a rst table of accuracy and runtime tables obtained
     through fitting a certain problem set by using various
@@ -50,6 +50,8 @@ def create(columns_txt, rows_txt, cells, comparison_type, comparison_dim,
     @param comparison_dim :: the comparison dimension, either acc or runtime
     @param using_errors :: boolean whether to use errors or not
     @param color_scale :: color scale for coloring the cells
+    @param comparison_mode :: str to select between 'abs', 'rel', 'both' for
+                              the style of comparison returned
 
     @returns :: rst table of the results
     """
@@ -57,7 +59,8 @@ def create(columns_txt, rows_txt, cells, comparison_type, comparison_dim,
     columns_txt = display_name_for_minimizers(columns_txt)
     items_link = \
         build_items_links(comparison_type, comparison_dim, using_errors)
-    cell_len = calc_cell_len(columns_txt, items_link, cells, color_scale)
+
+    cell_len = calc_cell_len(columns_txt, items_link, cells, color_scale, mode=comparison_mode)
 
     # The first column tends to be disproportionately long if it has a link
     first_col_len = calc_first_col_len(cell_len, rows_txt)
@@ -67,13 +70,13 @@ def create(columns_txt, rows_txt, cells, comparison_type, comparison_dim,
     tbl_header = tbl_htop + '\n' + tbl_htext + '\n' + tbl_hbottom + '\n'
     tbl_footer = tbl_htop + '\n'
     tbl_body = create_table_body(cells, items_link, rows_txt, first_col_len,
-                                 cell_len, color_scale, tbl_footer)
+                                 cell_len, color_scale, tbl_footer, mode=comparison_mode)
 
     return tbl_header + tbl_body
 
 
 def create_table_body(cells, items_link, rows_txt, first_col_len, cell_len,
-                      color_scale, tbl_footer):
+                      color_scale, tbl_footer, mode):
     """
     Creates the body of the rst table that holds all the fitting results.
 
@@ -85,21 +88,28 @@ def create_table_body(cells, items_link, rows_txt, first_col_len, cell_len,
     @param cell_len :: the length of the cells in the table
     @param color_scale :: color scale for coloring the cells
     @param tbl_footer :: the rst footer of the table
+    @param mode :: str to select between 'abs', 'rel', 'both' for
+                   the style of comparison returned
 
     @returns :: the rst table body
     """
 
     tbl_body = ''
     for row in range(0, cells.shape[0]):
-        link = items_link
+
         all_fit_failed_status = ''
-        if np.isnan(cells[row, :]).all():
+        if np.isnan(cells[row, :, 0]).all():
             all_fit_failed_status = '(all fit failed)'
+
         tbl_body += '|' + rows_txt[row].ljust(first_col_len-len(all_fit_failed_status), ' ')\
-                    + all_fit_failed_status +'|'
+                    + all_fit_failed_status + '|'
+
         for col in range(0, cells.shape[1]):
-            tbl_body += format_cell_value(cells[row, col], cell_len,
-                                          color_scale, link)
+            tbl_body += format_cell_value(value=cells[row, col],
+                                          width=cell_len,
+                                          color_scale=color_scale,
+                                          items_link=items_link,
+                                          mode=mode)
             tbl_body += '|'
 
         tbl_body += '\n' + tbl_footer
@@ -107,7 +117,7 @@ def create_table_body(cells, items_link, rows_txt, first_col_len, cell_len,
     return tbl_body
 
 
-def calc_cell_len(columns_txt, items_link, cells, color_scale=None):
+def calc_cell_len(columns_txt, items_link, cells, color_scale=None, mode='abs'):
     """
     Calculates the cell length of the rst table.
 
@@ -115,16 +125,19 @@ def calc_cell_len(columns_txt, items_link, cells, color_scale=None):
     @param items_link :: link to the items
     @param cells :: numpy array of the results (either runtime or accuracy)
     @param color_scale :: color scale for coloring the cells
+    @param mode :: str to select between 'abs', 'rel', 'both' for
+                   the style of comparison returned
 
     @returns :: the cell length of the rest table
     """
 
     max_header = len(max((col for col in columns_txt), key=len))
-    max_value = max(("%.4g" % cell for cell in np.nditer(cells)), key=len)
+    max_value = max(cells.reshape((-1, 2)), key=lambda x: len(cell_to_string(x, mode)))
     max_item = determine_max_item(items_link)
-    cell_len = len(format_cell_value(value=float(max_value),
+    cell_len = len(format_cell_value(value=max_value,
                                      color_scale=color_scale,
-                                     items_link=max_item).strip()) + 2
+                                     items_link=max_item,
+                                     mode=mode).strip()) + 2
     if cell_len < max_header:
         cell_len = max_header
 
@@ -199,7 +212,7 @@ def build_header_chunks(first_col_len, cell_len, columns_txt):
     return tbl_header_top, tbl_header_text, tbl_header_bottom
 
 
-def format_cell_value(value, width=None, color_scale=None, items_link=None):
+def format_cell_value(value, width=None, color_scale=None, items_link=None, mode='abs'):
     """
     Formats the cell values and adds color if a color scale is provided.
 
@@ -207,13 +220,18 @@ def format_cell_value(value, width=None, color_scale=None, items_link=None):
     @param width :: the width of the cell if it is given
     @param color_scale :: color scale for coloring the cells
     @param items_links :: items_link string or array
+    @param mode :: str to select between 'abs', 'rel', 'both' for
+                   the style of comparison returned
 
     @returns :: the correct value text string
     """
+
+    value_text = cell_to_string(value, mode)
+
     if not color_scale:
-        value_text = no_color_scale_cv(items_link, value)
+        value_text = no_color_scale_cv(items_link, value_text)
     else:
-        value_text = color_scale_cv(color_scale, value)
+        value_text = color_scale_cv(color_scale, value[1], value_text)
 
     if width is not None:
         value_text = value_text.ljust(width, ' ')
@@ -221,30 +239,32 @@ def format_cell_value(value, width=None, color_scale=None, items_link=None):
     return value_text
 
 
-def no_color_scale_cv(items_link, value):
+def no_color_scale_cv(items_link, value_text):
     """
     Creates the values text if no color scale is provided.
 
     @param items_links :: items_link string or array
+    @param value_text :: text representing the value for the cell
 
     @returns :: the no coloring value text string, containing
                 the items_links
     """
 
     if not items_link:
-        value_text = ' {0:.4g}'.format(value)
+        value_text = ' {}'.format(value_text)
     else:
-        value_text = ' :ref:`{0:.4g} <{1}>`'.format(value, items_link)
+        value_text = ' :ref:`{0} <{1}>`'.format(value_text, items_link)
 
     return value_text
 
 
-def color_scale_cv(color_scale, value):
+def color_scale_cv(color_scale, value, text):
     """
     Creates the values text if a color scale is provided.
 
     @param color_scale :: color scale for coloring the cells
     @param value :: the values of the color if it is added
+    @param text :: the cell text
 
     @returns :: the value text with added color values
     """
@@ -257,7 +277,7 @@ def color_scale_cv(color_scale, value):
     if not color:
         color = color_scale[-1][1]
 
-    value_text = " :{0}:`{1:.4g}`".format(color, value)
+    value_text = " :{0}:`{1}`".format(color, text)
 
     return value_text
 
@@ -325,3 +345,27 @@ def convert_rst_to_html(table_data):
     table_data = publish_string(rst_content, writer_name='html')
 
     return table_data
+
+
+def cell_to_string(value, mode='abs'):
+    """
+    Utility function to choose display mode. Options for mode are:
+     'abs' - The value as it was returned
+     'rel' - The value relative to other values (smallest is 1)
+     'both' - The 'abs' result followed by the 'rel' result in brackets
+
+    @param value :: The value to convert
+    @param mode :: The display mode
+
+    @returns :: String with the correct formatting 
+    """
+
+    if mode not in ['abs', 'rel', 'both']:
+        raise ValueError('Could not decifer mode "{}". Please select from "abs", "rel", or "both"'.format(mode))
+
+    if mode == 'both':
+        return '{:.4g} ({:.4g})'.format(value[0], value[1])  # NOQA
+    elif mode == 'rel':
+        return '{:.4g}'.format(value[1])  # NOQA
+    else:
+        return '{:.4g}'.format(value[0])  # NOQA

--- a/fitbenchmarking/resproc/tests/test_numpy_restables.py
+++ b/fitbenchmarking/resproc/tests/test_numpy_restables.py
@@ -1,4 +1,4 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 import unittest
 import os
@@ -11,9 +11,9 @@ parent_dir = os.path.dirname(os.path.normpath(test_dir))
 main_dir = os.path.dirname(os.path.normpath(parent_dir))
 sys.path.insert(0, main_dir)
 
-from resproc.numpy_restables import create_accuracy_runtime_tbls
-from resproc.numpy_restables import create_norm_tbls
-from resproc.numpy_restables import create_summary_tbls
+from resproc.numpy_restables import (create_accuracy_runtime_tbls,
+                                     create_combined_tbls, create_norm_tbls,
+                                     create_summary_tbls)
 from utils import fitbm_result
 
 
@@ -55,6 +55,16 @@ class NumpyRestablesTests(unittest.TestCase):
                               [5, 1, 180]])
 
     return norm_acc_rankings, norm_runtimes
+  
+  def expected_combined_mock_tables(self):
+
+    combined_acc = np.array([[[1, 1], [2, 2], [3, 3]],
+                             [[20, 5], [4, 1], [720, 180]]])
+
+    combined_run = np.array([[[1, 1], [2, 2], [3, 3]],
+                             [[20, 5], [4, 1], [720, 180]]])
+                            
+    return combined_acc, combined_run
 
   def expected_summary_mock_tables(self):
 
@@ -97,13 +107,29 @@ class NumpyRestablesTests(unittest.TestCase):
                                   norm_acc_rankings)
     np.testing.assert_array_equal(norm_runtimes_expected, norm_runtimes)
 
-  def test_createSummaryTbls_return_normalised_tables_given_mock_tables(self):
+  def test_createCombinedTbls_return_combined_tables_given_mock_tables(self):
+
+    accuracy_tbl, time_tbl = self.accuracy_and_runtime_mock_tables()
 
     norm_acc_rankings, norm_runtimes = \
         self.expected_normalised_mock_tables()
 
+    combined_acc, combined_run = create_combined_tbls(abs_accuracy=accuracy_tbl,
+                                                      rel_accuracy=norm_acc_rankings,
+                                                      abs_runtime=time_tbl,
+                                                      rel_runtime=norm_runtimes)
+
+    combined_acc_expected, combined_run_expected = self.expected_combined_mock_tables()
+
+    np.testing.assert_array_equal(combined_acc_expected, combined_acc)
+    np.testing.assert_array_equal(combined_run_expected, combined_run)
+
+  def test_createSummaryTbls_return_normalised_tables_given_mock_tables(self):
+
+    combined_acc, combined_run = self.expected_combined_mock_tables()
+
     summary_cells_acc, summary_cells_runtime = \
-        create_summary_tbls(norm_acc_rankings, norm_runtimes)
+        create_summary_tbls(combined_acc, combined_run)
     summary_cells_acc_expected, summary_cells_runtime_expected = \
         self.expected_summary_mock_tables()
 

--- a/fitbenchmarking/resproc/tests/test_rst_table.py
+++ b/fitbenchmarking/resproc/tests/test_rst_table.py
@@ -83,8 +83,8 @@ class RstTableTests(unittest.TestCase):
                    'Minimizer5', 'Minimizer6', 'Minimizer7', 'Minimizer8',
                    'Minimizer9', 'Trust Region']
     items_link = 'FittingMinimizersComparisonDetailedWithWeights'
-    cells = np.array([[1, 2, 3],
-                      [5, 10, 13]])
+    cells = np.array([[[0.1, 1], [0.2, 2], [0.3, 3]],
+                      [[0.5, 5], [1, 10], [13, 13]]])
     color_scale = [(1.1, 'ranking-top-1'),
                    (1.33, 'ranking-top-2'),
                    (1.75, 'ranking-med-3'),
@@ -103,8 +103,8 @@ class RstTableTests(unittest.TestCase):
                 "/dump/nist/VDPages/nist_lower_misra1a.html>`__",
                 "`Misra1a 2 <file:///" + current_dir +
                 "/dump/nist/VDPages/nist_lower_misra1a.html>`__"]
-    cells = np.array([[1, 2, 3],
-                      [5, 10, 13]])
+    cells = np.array([[[2, 1], [4, 2], [6, 3]],
+                      [[10, 5], [20, 10], [26, 13]]])
 
     color_scale = [(1.1, 'ranking-top-1'),
                    (1.33, 'ranking-top-2'),
@@ -119,7 +119,7 @@ class RstTableTests(unittest.TestCase):
     columns_txt, rows_txt, cells, color_scale = self.CreateTableInputData()
 
     table = create(columns_txt, rows_txt, cells, 'accuracy', '',
-                   True, color_scale)
+                   True, color_scale, comparison_mode='rel')
     table_expected = self.GenerateExpectedTable()
 
     self.assertEqual(table_expected, table)
@@ -134,7 +134,7 @@ class RstTableTests(unittest.TestCase):
     tbl_footer = tbl_header_top + '\n'
 
     tbl_body = create_table_body(cells, items_link, rows_txt, first_col_len,
-                                 21, color_scale, tbl_footer)
+                                 21, color_scale, tbl_footer, mode='rel')
     tbl_body_expected = self.GenerateTableBody() + tbl_footer
 
     self.assertEqual(tbl_body_expected, tbl_body)
@@ -144,7 +144,7 @@ class RstTableTests(unittest.TestCase):
     columns_txt, items_link, cells, color_scale = \
         self.CalcCellLenParameters()
 
-    cell_len = calc_cell_len(columns_txt, items_link, cells, color_scale)
+    cell_len = calc_cell_len(columns_txt, items_link, cells, color_scale, mode='rel')
     cell_len_expected = 21
 
     self.assertEqual(cell_len_expected, cell_len)
@@ -162,24 +162,37 @@ class RstTableTests(unittest.TestCase):
 
   def test_FormatCellValue_no_colorscale_and_itemslink_return_valuetxt(self):
 
-    value_text = format_cell_value(value=180, color_scale=0,
-                                   items_link=0)
-    self.assertEqual(' 180', value_text)
+    value = [180, 10]
+    expected = [' 180', ' 10', ' 180 (10)']
+    mode = ['abs', 'rel', 'both']
+
+    for e, m in zip(expected, mode):
+      value_text = format_cell_value(value=value,
+                                     color_scale=0,
+                                     items_link=0,
+                                     mode=m)
+      self.assertEqual(e, value_text)
 
   def test_FormatCellValue_no_color_scale_return_value_text(self):
 
     items_link = 'FittingMinimizersComparisonDetailedWithWeights'
+    value = [10, 180]
+    mode = ['abs', 'rel', 'both']
+    expected = [' :ref:`10 <FittingMinimizersComparisonDetailedWithWeights>`',
+                ' :ref:`180 <FittingMinimizersComparisonDetailedWithWeights>`',
+                ' :ref:`10 (180) <FittingMinimizersComparisonDetailedWithWeights>`']
 
-    value_text = format_cell_value(value=180, color_scale=0,
-                                   items_link=items_link)
-    value_text_expected = \
-        ' :ref:`180 <FittingMinimizersComparisonDetailedWithWeights>`'
+    for e, m in zip(expected, mode):
+      value_text = format_cell_value(value=value,
+                                     color_scale=0,
+                                     items_link=items_link,
+                                     mode=m)
+      self.assertEqual(e, value_text)
 
-    self.assertEqual(value_text_expected, value_text)
 
   def test_FormatCellValueRST_all_options_no_width_return_value_text(self):
 
-    value = 2
+    value = [1, 2]
     color_scale = [(1.1, 'ranking-top-1'),
                    (1.33, 'ranking-top-2'),
                    (1.75, 'ranking-med-3'),
@@ -189,13 +202,13 @@ class RstTableTests(unittest.TestCase):
 
     value_text = format_cell_value(value=value, color_scale=color_scale,
                                    items_link=items_link)
-    value_text_expected = " :ranking-low-4:`2`"
+    value_text_expected = " :ranking-low-4:`1`"
 
     self.assertEqual(value_text_expected, value_text)
 
   def test_FormatCellValueRST_all_options_with_width_return_value_text(self):
 
-    value = 180
+    value = [180, 300]
     color_scale = [(1.1, 'ranking-top-1'),
                    (1.33, 'ranking-top-2'),
                    (1.75, 'ranking-med-3'),

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -31,7 +31,7 @@ from utils.logging_setup import logger
 from resproc import numpy_restables
 from resproc import rst_table
 from resproc import visual_pages
-from utils import create_dirs
+from utils import create_dirs, options
 
 # Some naming conventions for the output files
 FILENAME_SUFFIX_ACCURACY = 'acc'
@@ -57,6 +57,19 @@ def save_results_tables(software_options, results_per_test, group_name,
     """
 
     minimizers, software = utils.misc.get_minimizers(software_options)
+    comparison_type = software_options.get('comparison_type', None)
+
+    if comparison_type is None:
+        if 'options_file' in software_options:
+            options_file = software_options['options_file']
+            comparison_mode = options.get_option(options_file=options_file,
+                                                 option='comparison_mode')
+        else:
+            comparison_mode = options.get_option(option='comparison_mode')
+
+        if comparison_mode is None:
+            comparison_mode = 'both'
+
     if isinstance(software, list):
         minimizers = sum(minimizers, [])
 
@@ -64,13 +77,25 @@ def save_results_tables(software_options, results_per_test, group_name,
     linked_problems = \
         visual_pages.create_linked_probs(results_per_test, group_name, results_dir)
 
-    norm_acc_rankings, norm_runtimes, sum_cells_acc, sum_cells_runtime = \
-        generate_tables(results_per_test, minimizers)
+    acc_rankings, runtimes, _, _ = generate_tables(results_per_test, minimizers)
 
-    acc_tbl = create_acc_tbl(minimizers, linked_problems, norm_acc_rankings,
-                             use_errors, color_scale)
-    runtime_tbl = create_runtime_tbl(minimizers, linked_problems, norm_runtimes,
-                                     use_errors, color_scale)
+    acc_tbl = rst_table.create(columns_txt=minimizers,
+                               rows_txt=linked_problems,
+                               cells=acc_rankings,
+                               comparison_type='accuracy',
+                               comparison_dim='',
+                               using_errors=use_errors,
+                               color_scale=color_scale,
+                               comparison_mode=comparison_mode)
+
+    runtime_tbl = rst_table.create(columns_txt=minimizers,
+                                   rows_txt=linked_problems,
+                                   cells=runtimes,
+                                   comparison_type='runtime',
+                                   comparison_dim='',
+                                   using_errors=use_errors,
+                                   color_scale=color_scale,
+                                   comparison_mode=comparison_mode)
 
     save_tables(tables_dir, acc_tbl, use_errors, group_name,
                 FILENAME_SUFFIX_ACCURACY)
@@ -83,53 +108,29 @@ def save_results_tables(software_options, results_per_test, group_name,
 
 def generate_tables(results_per_test, minimizers):
     """
-    Generates accuracy and runtime normalised tables and summary tables.
+    Generates accuracy and runtime tables, with both normalised and absolute results, and summary tables.
 
     @param results_per_test :: results nested array of objects
     @param minimizers :: array with minimizer names
 
-    @returns :: normalised and summary tables of the results as np arrays
+    @returns :: data and summary tables of the results as np arrays
     """
 
     accuracy_tbl, runtime_tbl = \
         numpy_restables.create_accuracy_runtime_tbls(results_per_test, minimizers)
+
     norm_acc_rankings, norm_runtimes = \
         numpy_restables.create_norm_tbls(accuracy_tbl, runtime_tbl)
+
+    accuracy_tbl, runtime_tbl = numpy_restables.create_combined_tbls(abs_accuracy=accuracy_tbl,
+                                                                     rel_accuracy=norm_acc_rankings,
+                                                                     abs_runtime=runtime_tbl,
+                                                                     rel_runtime=norm_runtimes)
+
     sum_cells_acc, sum_cells_runtime = \
-        numpy_restables.create_summary_tbls(norm_acc_rankings, norm_runtimes)
+        numpy_restables.create_summary_tbls(accuracy_tbl, runtime_tbl)
 
-    return norm_acc_rankings, norm_runtimes, sum_cells_acc, sum_cells_runtime
-
-
-def create_acc_tbl(minimizers, linked_problems, norm_acc_rankings, use_errors,
-                   color_scale):
-    """
-    Creates an accuracy table using the given parameters.
-    """
-    # Save accuracy table for this group of fit problems
-    tbl_acc_indiv = rst_table.create(minimizers, linked_problems,
-                                     norm_acc_rankings,
-                                     comparison_type='accuracy',
-                                     comparison_dim='',
-                                     using_errors=use_errors,
-                                     color_scale=color_scale)
-
-    return tbl_acc_indiv
-
-
-def create_runtime_tbl(minimizers, linked_problems, norm_runtimes, use_errors,
-                       color_scale):
-    """
-    Creates a runtime table using the given paramters.
-    """
-    tbl_runtime_indiv = rst_table.create(minimizers, linked_problems,
-                                         norm_runtimes,
-                                         comparison_type='runtime',
-                                         comparison_dim='',
-                                         using_errors=use_errors,
-                                         color_scale=color_scale)
-
-    return tbl_runtime_indiv
+    return accuracy_tbl, runtime_tbl, sum_cells_acc, sum_cells_runtime
 
 
 def save_tables(tables_dir, table_data, use_errors, group_name, metric):

--- a/fitbenchmarking/utils/misc.py
+++ b/fitbenchmarking/utils/misc.py
@@ -27,8 +27,8 @@ from __future__ import absolute_import, division, print_function
 import glob
 import os
 
-from fitbenchmarking.utils import options, user_input
-from fitbenchmarking.utils.logging_setup import logger
+from utils import options, user_input
+from utils.logging_setup import logger
 
 
 def get_minimizers(software_options):
@@ -51,13 +51,15 @@ def get_minimizers(software_options):
                          'keys software and minimizer_options')
 
     if minimizer_options is None:
-        minimizers_list = options.get_option(option='minimizers')
-    elif isinstance(minimizer_options, str):
-        minimizers_list = options.get_option(options_file=minimizer_options, option='minimizers')
+        options_file = software_options.get('options_file', None)
+        if options_file is None:
+            minimizers_list = options.get_option(option='minimizers')
+        else:
+            minimizers_list = options.get_option(options_file=options_file, option='minimizers')
     elif isinstance(minimizer_options, dict):
         minimizers_list = minimizer_options
     else:
-        raise ValueError('minimizer_options required to be None, string '
+        raise ValueError('minimizer_options required to be None '
                          'or dictionary, type(minimizer_options) '
                          '= {}'.format(type(minimizer_options)))
 

--- a/fitbenchmarking/utils/options.py
+++ b/fitbenchmarking/utils/options.py
@@ -23,4 +23,4 @@ def get_option(options_file='fitbenchmarking/fitbenchmarking_default_options.jso
         try:
             return options[option]
         except KeyError:
-            raise ValueError('Option not found in file: {}'.format(options_file))
+            raise ValueError('Option "{}" not found in file: {}'.format(option, options_file))

--- a/fitbenchmarking/utils/tests/test_misc.py
+++ b/fitbenchmarking/utils/tests/test_misc.py
@@ -121,7 +121,8 @@ class CreateDirsTests(unittest.TestCase):
 
   def test_getMinimizers_load_correct_minimizers_scipy_read_file(self):
     software_options = {'software': 'scipy',
-                        'minimizer_options': self.get_minimizers_file()}
+                        'minimizer_options': None,
+                        'options_file': self.get_minimizers_file()}
 
     minimizers, _ = get_minimizers(software_options)
     minmizers_expected = ["lm", "trf", "dogbox"]
@@ -131,7 +132,8 @@ class CreateDirsTests(unittest.TestCase):
   def test_getMinimizers_load_correct_minimizers_mantid_read_file(self):
 
     software_options = {'software': 'mantid',
-                        'minimizer_options': self.get_minimizers_file()}
+                        'minimizer_options': None,
+                        'options_file': self.get_minimizers_file()}
 
     minimizers, _ = get_minimizers(software_options)
     minmizers_expected = ["BFGS", "Conjugate gradient (Fletcher-Reeves imp.)",
@@ -146,7 +148,8 @@ class CreateDirsTests(unittest.TestCase):
   def test_getMinimizers_load_correct_compare_minimizers_mantid_read_file(self):
 
     software_options = {'software': ['mantid', 'scipy'],
-                        'minimizer_options': self.get_minimizers_file()}
+                        'minimizer_options': None,
+                        'options_file': self.get_minimizers_file()}
 
     minimizers, _ = get_minimizers(software_options)
     minmizers_expected = [["BFGS", "Conjugate gradient (Fletcher-Reeves imp.)",


### PR DESCRIPTION
… relative, or both

#### Description of Work
Add an option 'comparison_mode' to the options file. This will change the value reported in the results table.
If comparison_mode is:
- 'abs' : it will report the absolute value from the run (note: the colour will still be relative to the other results)
- 'rel' : it will function as it did before this change
- 'both' : it will display the absolute value followed by the relative in parentheses. e.g. 0.001274 (1)

Fixes #134

#### Testing Instructions

1. Set 'comparison_mode' in options file
2. Run example scripts
3. Check output is as expected
