### PR TITLE
257 Adding averaging time using timeit

### DIFF
--- a/docs/source/users/options.rst
+++ b/docs/source/users/options.rst
@@ -118,7 +118,7 @@ Scipy:
   - ``"dogbox"``
   - ``"lm"``
   - and ``"trf"``
- 
+
 
   Information about these can be found on the
   `Scipy documentation
@@ -128,9 +128,9 @@ DFO-GN:
   - ``"dfogn"``
   Information about this can be found on the
   `DFO-GN documentation
-  <http://people.maths.ox.ac.uk/robertsl/dfogn/>`__  
-  
-  
+  <http://people.maths.ox.ac.uk/robertsl/dfogn/>`__
+
+
 ``comparison_mode``
 -------------------
 The comparison mode is used when displaying results to select the value
@@ -152,3 +152,11 @@ Available options are ``"abs"``, ``"rel"``, or ``"both"``.
   Return both absolute and relative values.
   Values will be shown as an absolute value followed by a relative value in
   parentheses.
+
+
+``num_runs``
+-------------------
+
+Number of runs is used to define how many times FitBenchmarking calls a minimizer and thus calculates an average elapsed time using `timeit`.
+
+Default set as `5`.

--- a/docs/source/users/options.rst
+++ b/docs/source/users/options.rst
@@ -164,6 +164,6 @@ Available options are ``"abs"``, ``"rel"``, or ``"both"``.
 ``num_runs``
 -------------------
 
-Number of runs is used to define how many times FitBenchmarking calls a minimizer and thus calculates an average elapsed time using ``timeit``.
+Number of runs is defines how many times FitBenchmarking calls a minimizer and thus calculates an average elapsed time using ``timeit``.
 
 Default set as ``5``.

--- a/docs/source/users/options.rst
+++ b/docs/source/users/options.rst
@@ -157,6 +157,6 @@ Available options are ``"abs"``, ``"rel"``, or ``"both"``.
 ``num_runs``
 -------------------
 
-Number of runs is used to define how many times FitBenchmarking calls a minimizer and thus calculates an average elapsed time using `timeit`.
+Number of runs is used to define how many times FitBenchmarking calls a minimizer and thus calculates an average elapsed time using ``timeit``.
 
-Default set as `5`.
+Default set as ``5``.

--- a/example_scripts/example_runScripts_expert.py
+++ b/example_scripts/example_runScripts_expert.py
@@ -11,8 +11,7 @@ import sys
 import glob
 
 from fitbenchmarking.fitting_benchmarking import _benchmark
-from fitbenchmarking.utils import misc
-from fitbenchmarking.utils import create_dirs
+from fitbenchmarking.utils import create_dirs, misc, options
 from fitbenchmarking.results_output import save_tables, generate_tables, \
     create_acc_tbl, create_runtime_tbl
 from fitbenchmarking.resproc import visual_pages

--- a/example_scripts/example_runScripts_expert.py
+++ b/example_scripts/example_runScripts_expert.py
@@ -89,7 +89,15 @@ def main(argv):
 
         # Processes software_options dictionary into Fitbenchmarking format
         minimizers, software = misc.get_minimizers(software_options)
+        num_runs = software_options.get('num_runs', None)
 
+        if num_runs is None:
+            if 'num_runs' in software_options:
+                options_file = software_options['num_runs']
+                num_runs = options.get_option(options_file=options_file,
+                                              option='num_runs')
+            else:
+                num_runs = options.get_option(option='num_runs')
         # Sets up the problem group specified by the user by providing
         # a respective data directory.
         problem_group = misc.get_problem_files(data_dir)
@@ -103,7 +111,7 @@ def main(argv):
                                           group_results_dir, use_errors)
 
         # Loops through group of problems and benchmark them
-        prob_results = _benchmark(user_input, problem_group)
+        prob_results = _benchmark(user_input, problem_group, num_runs)
 
         print('\nProducing output for the {} problem set\n'.format(group_name))
 

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -118,13 +118,16 @@ def benchmark(controller, minimizers, num_runs):
     for minimizer in minimizers:
         controller.minimizer = minimizer
 
-        controller.prepare()
-
         init_function_def = controller.problem.get_function_def(
             params=controller.initial_params,
             function_id=controller.function_id)
         try:
-            runtime = timeit.timeit(controller.fit, number=num_runs) / num_runs
+            # Calls timeit repeat with repeat = num_runs and number = 1
+            runtime_list = \
+                timeit.Timer(setup=controller.prepare,
+                             stmt=controller.fit).repeat(num_runs, 1)
+            runtime = sum(runtime_list) / num_runs
+
         except Exception as e:
             print(e.message)
             controller.success = False

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -38,13 +38,17 @@ def fitbm_one_prob(user_input, problem, num_runs):
     provided in the problem object. The best fit, along with the data and a
     starting guess is then plotted on a visual display page.
 
-    @param user_input :: all the information specified by the user
-    @param problem :: a problem object containing information used in fitting
-    @param num_runs :: number of times controller.fit() is run to
+    :param user_input :: all the information specified by the user
+    :type user_input :: UserInput
+    :param problem :: a problem object containing information used in fitting
+    :type problem :: FittingProblem
+    :param num_runs :: number of times controller.fit() is run to
                        generate an average runtime
+    :type num_runs :: int
 
-    @returns :: nested array of result objects, per function definition
-                containing the fit information
+    :return :: nested array of result objects, per function definition
+               containing the fit information
+    :rtype :: list
     """
 
     results_fit_problem = []
@@ -94,13 +98,19 @@ def benchmark(controller, minimizers, num_runs):
     Fit benchmark one problem, with one function definition and all
     the selected minimizers, using the chosen fitting software.
 
-    @param controller :: The software controller for the fitting
+    :param controller :: The software controller for the fitting
+    :type controller :: Object derived from BaseSoftwareController
     @param minimizers :: array of minimizers used in fitting
+    :type minimizers :: list
     @param num_runs :: number of times controller.fit() is run to
                        generate an average runtime
+    :type num_runs :: int
 
-    @returns :: nested array of result objects, per minimizer
-                and data object for the best fit data
+
+    :return :: tuple(results_problem, best_fit) nested array of
+               result objects, per minimizer and data object for
+               the best fit data
+    :rtype :: list of FittingResult, plot_helper.data instance
     """
     min_chi_sq, best_fit = None, None
     results_problem = []

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -5,7 +5,7 @@ Fit benchmark one problem functions.
 from __future__ import absolute_import, division, print_function
 
 import timeit
-
+import warnings
 import numpy as np
 
 from fitbenchmarking.fitting import misc
@@ -145,11 +145,12 @@ def benchmark(controller, minimizers, num_runs):
             chi_sq = np.nan
             status = 'failed'
         else:
-            cv = np.std(runtime_list) / np.mean(runtime_list)
-            if cv > 0.2:
-                raise Warning('The ratio of the standard deviation and mean'
-                              ' is larger than {}, this may indicate caching'
-                              ' is used in the timing results.'.format())
+            ratio = np.max(runtime_list) / np.min(runtime_list)
+            if ratio > 4:
+                warnings.warn('The ratio of the max time to the min is {0}'
+                              ' which is  larger than the tolerance of {1},'
+                              ' which may indicate that caching has occurred'
+                              ' in the timing results'.format(ratio, 4))
 
             chi_sq = misc.compute_chisq(fitted=controller.results,
                                         actual=controller.data_y,

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -128,8 +128,10 @@ def benchmark(controller, minimizers, num_runs):
                              stmt=controller.fit).repeat(num_runs, 1)
             runtime = sum(runtime_list) / num_runs
 
-        except Exception as e:
-            print(e.message)
+        # Catching all exceptions as this means runtime cannot be calculated
+        # pylint: disable=broad-except
+        except Exception as excp:
+            print(str(excp))
             controller.success = False
             runtime = np.inf
 

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -146,12 +146,12 @@ def benchmark(controller, minimizers, num_runs):
             status = 'failed'
         else:
             ratio = np.max(runtime_list) / np.min(runtime_list)
-            if ratio > 4:
+            tol = 4
+            if ratio > tol:
                 warnings.warn('The ratio of the max time to the min is {0}'
                               ' which is  larger than the tolerance of {1},'
                               ' which may indicate that caching has occurred'
-                              ' in the timing results'.format(ratio, 4))
-
+                              ' in the timing results'.format(ratio, tol))
             chi_sq = misc.compute_chisq(fitted=controller.results,
                                         actual=controller.data_y,
                                         errors=controller.data_e)

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -110,7 +110,7 @@ def benchmark(controller, minimizers, num_runs):
     :return :: tuple(results_problem, best_fit) nested array of
                result objects, per minimizer and data object for
                the best fit data
-    :rtype :: list of FittingResult, plot_helper.data instance
+    :rtype :: (list of FittingResult, plot_helper.data instance)
     """
     min_chi_sq, best_fit = None, None
     results_problem = []

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -143,6 +143,12 @@ def benchmark(controller, minimizers, num_runs):
             chi_sq = np.nan
             status = 'failed'
         else:
+            cv = np.std(runtime_list) / np.mean(runtime_list)
+            if cv > 0.2:
+                raise Warning('The ratio of the standard deviation and mean'
+                              ' is larger than {}, this may indicate caching'
+                              ' is used in the timing results.'.format())
+
             chi_sq = misc.compute_chisq(fitted=controller.results,
                                         actual=controller.data_y,
                                         errors=controller.data_e)

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -55,7 +55,8 @@ def fitbm_one_prob(user_input, problem, num_runs):
     if software in controllers:
         controller = controllers[software](problem, user_input.use_errors)
     else:
-        raise NotImplementedError('The chosen software is not implemented yet: {}'.format(user_input.software))
+        raise NotImplementedError('The chosen software is not implemented yet:'
+                                  '{}'.format(user_input.software))
 
     # The controller reformats the data to fit within a start- and end-x bound
     # It also estimates errors if not provided.
@@ -104,8 +105,9 @@ def benchmark(controller, minimizers, num_runs):
 
         controller.prepare()
 
-        init_function_def = controller.problem.get_function_def(params=controller.initial_params,
-                                                                function_id=controller.function_id)
+        init_function_def = controller.problem.get_function_def(
+            params=controller.initial_params,
+            function_id=controller.function_id)
         try:
             runtime = timeit.timeit(controller.fit, number=num_runs) / num_runs
         except Exception as e:
@@ -115,8 +117,9 @@ def benchmark(controller, minimizers, num_runs):
 
         controller.cleanup()
 
-        fin_function_def = controller.problem.get_function_def(params=controller.final_params,
-                                                               function_id=controller.function_id)
+        fin_function_def = controller.problem.get_function_def(
+            params=controller.final_params,
+            function_id=controller.function_id)
 
         if not controller.success:
             chi_sq = np.nan

--- a/fitbenchmarking/fitbenchmarking_default_options.json
+++ b/fitbenchmarking/fitbenchmarking_default_options.json
@@ -11,5 +11,7 @@
         "dfogn" : ["dfogn"]
         },
 
-    "comparison_mode" : "both" 
+    "comparison_mode" : "both",
+
+    "num_runs" : 5
 }

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -11,82 +11,97 @@ import json
 from fitbenchmarking.utils.logging_setup import logger
 
 from fitbenchmarking.parsing import parse
-from fitbenchmarking.utils import create_dirs, misc
+from fitbenchmarking.utils import create_dirs, misc, options
 from fitbenchmarking.fitbenchmark_one_problem import fitbm_one_prob
 
 
 def fitbenchmark_group(group_name, software_options, data_dir,
                        use_errors=True, results_dir=None):
-    """
-    Gather the user input and list of paths. Call benchmarking on these.
+  """
+  Gather the user input and list of paths. Call benchmarking on these.
 
-    @param group_name :: is the name (label) for a group. E.g. the name for the group of problems in
-                         "NIST/low_difficulty" may be picked to be NIST_low_difficulty
-    @param software_options :: dictionary containing software used in fitting the problem, list of minimizers and
-                               location of json file contain minimizers
-    @param data_dir :: full path of a directory that holds a group of problem definition files
-    @param use_errors :: whether to use errors on the data or not
-    @param results_dir :: directory in which to put the results. None
-                          means results directory is created for you
+  @param group_name :: is the name (label) for a group. E.g. the name for the group of problems in
+                       "NIST/low_difficulty" may be picked to be NIST_low_difficulty
+  @param software_options :: dictionary containing software used in fitting the problem, list of minimizers and
+                             location of json file contain minimizers
+  @param data_dir :: full path of a directory that holds a group of problem definition files
+  @param use_errors :: whether to use errors on the data or not
+  @param results_dir :: directory in which to put the results. None
+                        means results directory is created for you
 
-    @returns :: array of fitting results for the problem group and
-                the path to the results directory
-    """
+  @returns :: array of fitting results for the problem group and
+              the path to the results directory
+  """
 
-    logger.info("Loading minimizers from {0}".format(
-        software_options['software']))
-    minimizers, software = misc.get_minimizers(software_options)
+  logger.info("Loading minimizers from {0}".format(
+      software_options['software']))
+  minimizers, software = misc.get_minimizers(software_options)
+  num_runs = software_options.get('num_runs', None)
 
-    # create list of paths to all problem definitions in data_dir
-    problem_group = misc.get_problem_files(data_dir)
-
-    results_dir = create_dirs.results(results_dir)
-    group_results_dir = create_dirs.group_results(results_dir, group_name)
-
-    user_input = misc.save_user_input(software, minimizers, group_name,
-                                      group_results_dir, use_errors)
-
-    prob_results = _benchmark(user_input, problem_group)
-
-    return prob_results, results_dir
-
-
-def _benchmark(user_input, problem_group):
-    """
-    Loops through software and benchmarks each problem within the problem
-    group.
-
-    @param user_input :: all the information specified by the user
-    @param problem_group :: list of paths to problem files in the group
-                            e.g. ['NIST/low_difficulty/file1.dat',
-                                  'NIST/low_difficulty/file2.dat',
-                                  ...]
-
-    @returns :: array of result objects, per problem per user_input
-    """
-
-    parsed_problems = [parse.parse_problem_file(p) for p in problem_group]
-
-    if not isinstance(user_input, list):
-        list_prob_results = [per_func
-                             for p in parsed_problems
-                             for per_func in fitbm_one_prob(user_input, p)]
-
+  if num_runs is None:
+    if 'num_runs' in software_options:
+      options_file = software_options['num_runs']
+      num_runs = options.get_option(options_file=options_file,
+                                    option='num_runs')
     else:
-        list_prob_results = [[fitbm_one_prob(u, p)
-                              for u in user_input]
-                             for p in parsed_problems]
+      num_runs = options.get_option(option='num_runs')
 
-        # reorganise loop structure from:
-        # [[[val per minimizer] per function] per input] per problem]
-        # to:
-        # [[val per input per minimizer] per function per problem]
-        list_prob_results = \
-            [[list_prob_results[prob_idx][input_idx][func_idx][minim_idx]
-              for input_idx in range(len(user_input))
-              for minim_idx in range(len(list_prob_results[prob_idx][input_idx][func_idx]))]
-             for prob_idx in range(len(parsed_problems))
-             for func_idx in range(len(list_prob_results[prob_idx][0]))]
+    if num_runs is None:
+      num_runs = 5
 
-    return list_prob_results
+  # create list of paths to all problem definitions in data_dir
+  problem_group = misc.get_problem_files(data_dir)
 
+  results_dir = create_dirs.results(results_dir)
+  group_results_dir = create_dirs.group_results(results_dir, group_name)
+
+  user_input = misc.save_user_input(software, minimizers, group_name,
+                                    group_results_dir, use_errors)
+
+  prob_results = _benchmark(user_input, problem_group, num_runs)
+
+  return prob_results, results_dir
+
+
+def _benchmark(user_input, problem_group, num_runs=5):
+  """
+  Loops through software and benchmarks each problem within the problem
+  group.
+
+  @param user_input :: all the information specified by the user
+  @param problem_group :: list of paths to problem files in the group
+                          e.g. ['NIST/low_difficulty/file1.dat',
+                                'NIST/low_difficulty/file2.dat',
+                                ...]
+  @param num_runs :: number of times controller.fit() is run to
+                     generate an average runtime
+
+
+  @returns :: array of result objects, per problem per user_input
+  """
+
+  parsed_problems = [parse.parse_problem_file(p) for p in problem_group]
+
+  if not isinstance(user_input, list):
+    list_prob_results = [per_func
+                         for p in parsed_problems
+                         for per_func in fitbm_one_prob(user_input,
+                                                        p, num_runs)]
+
+  else:
+    list_prob_results = [[fitbm_one_prob(u, p, num_runs)
+                          for u in user_input]
+                         for p in parsed_problems]
+
+    # reorganise loop structure from:
+    # [[[val per minimizer] per function] per input] per problem]
+    # to:
+    # [[val per input per minimizer] per function per problem]
+    list_prob_results = \
+        [[list_prob_results[prob_idx][input_idx][func_idx][minim_idx]
+          for input_idx in range(len(user_input))
+          for minim_idx in range(len(list_prob_results[prob_idx][input_idx][func_idx]))]
+         for prob_idx in range(len(parsed_problems))
+         for func_idx in range(len(list_prob_results[prob_idx][0]))]
+
+  return list_prob_results

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -39,7 +39,7 @@ def fitbenchmark_group(group_name, software_options, data_dir,
 
     :return :: tuple(prob_results, results_dir) array of fitting results for
                 the problem group and the path to the results directory
-    :rtype :: list of FittingResult, str
+    :rtype :: (list of FittingResult, str)
     """
 
     logger.info("Loading minimizers from %s", software_options['software'])

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -20,20 +20,26 @@ def fitbenchmark_group(group_name, software_options, data_dir,
     """
     Gather the user input and list of paths. Call benchmarking on these.
 
-    @param group_name :: is the name (label) for a group. E.g. the name for the
+    :param group_name :: is the name (label) for a group. E.g. the name for the
                          group of problems in "NIST/low_difficulty" may be
                          picked to be NIST_low_difficulty
-    @param software_options :: dictionary containing software used in fitting
+    :type group_name :: str
+    :param software_options :: dictionary containing software used in fitting
                                the problem, list of minimizers and location of
                                json file contain minimizers
-    @param data_dir :: full path of a directory that holds a group of problem
+    :type software_options :: dict
+    :param data_dir :: full path of a directory that holds a group of problem
                        definition files
-    @param use_errors :: whether to use errors on the data or not
-    @param results_dir :: directory in which to put the results. None means
+    :type date_dir :: str
+    :param use_errors :: whether to use errors on the data or not
+    :type use_errors :: bool
+    :param results_dir :: directory in which to put the results. None means
                           results directory is created for you
+    :type results_dir :: str/NoneType
 
-    @returns :: array of fitting results for the problem group and the path to
-                the results directory
+    :return :: tuple(prob_results, results_dir) array of fitting results for
+                the problem group and the path to the results directory
+    :rtype :: list of FittingResult, str
     """
 
     logger.info("Loading minimizers from %s", software_options['software'])
@@ -47,9 +53,6 @@ def fitbenchmark_group(group_name, software_options, data_dir,
                                           option='num_runs')
         else:
             num_runs = options.get_option(option='num_runs')
-
-        if num_runs is None:
-            num_runs = 5
 
     # create list of paths to all problem definitions in data_dir
     problem_group = misc.get_problem_files(data_dir)
@@ -65,21 +68,26 @@ def fitbenchmark_group(group_name, software_options, data_dir,
     return prob_results, results_dir
 
 
-def _benchmark(user_input, problem_group, num_runs=5):
+def _benchmark(user_input, problem_group, num_runs):
     """
     Loops through software and benchmarks each problem within the problem
     group.
 
-    @param user_input :: all the information specified by the user
-    @param problem_group :: list of paths to problem files in the group
+    :param user_input :: all the information specified by the user
+    :type user_input :: UserInput
+    :param problem_group :: list of paths to problem files in the group
                           e.g. ['NIST/low_difficulty/file1.dat',
                                 'NIST/low_difficulty/file2.dat',
                                 ...]
-    @param num_runs :: number of times controller.fit() is run to
+    :type problem_group :: list
+    :param num_runs :: number of times controller.fit() is run to
                      generate an average runtime
+    :type num_runs :: str
 
 
-    @returns :: array of result objects, per problem per user_input
+    :return :: array of result objects, per problem per user_input
+    :rtype :: list of FittingResult
+
     """
 
     parsed_problems = [parse.parse_problem_file(p) for p in problem_group]

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -48,11 +48,14 @@ def fitbenchmark_group(group_name, software_options, data_dir,
 
     if num_runs is None:
         if 'num_runs' in software_options:
-            options_file = software_options['num_runs']
+            options_file = software_options['options_file']
             num_runs = options.get_option(options_file=options_file,
                                           option='num_runs')
         else:
             num_runs = options.get_option(option='num_runs')
+
+        if num_runs is None:
+            num_runs = 5
 
     # create list of paths to all problem definitions in data_dir
     problem_group = misc.get_problem_files(data_dir)

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -17,91 +17,94 @@ from fitbenchmarking.fitbenchmark_one_problem import fitbm_one_prob
 
 def fitbenchmark_group(group_name, software_options, data_dir,
                        use_errors=True, results_dir=None):
-  """
-  Gather the user input and list of paths. Call benchmarking on these.
+    """
+    Gather the user input and list of paths. Call benchmarking on these.
 
-  @param group_name :: is the name (label) for a group. E.g. the name for the group of problems in
-                       "NIST/low_difficulty" may be picked to be NIST_low_difficulty
-  @param software_options :: dictionary containing software used in fitting the problem, list of minimizers and
-                             location of json file contain minimizers
-  @param data_dir :: full path of a directory that holds a group of problem definition files
-  @param use_errors :: whether to use errors on the data or not
-  @param results_dir :: directory in which to put the results. None
-                        means results directory is created for you
+    @param group_name :: is the name (label) for a group. E.g. the name for the
+                         group of problems in "NIST/low_difficulty" may be
+                         picked to be NIST_low_difficulty
+    @param software_options :: dictionary containing software used in fitting
+                               the problem, list of minimizers and location of
+                               json file contain minimizers
+    @param data_dir :: full path of a directory that holds a group of problem
+                       definition files
+    @param use_errors :: whether to use errors on the data or not
+    @param results_dir :: directory in which to put the results. None means
+                          results directory is created for you
 
-  @returns :: array of fitting results for the problem group and
-              the path to the results directory
-  """
+    @returns :: array of fitting results for the problem group and the path to
+                the results directory
+    """
 
-  logger.info("Loading minimizers from {0}".format(
-      software_options['software']))
-  minimizers, software = misc.get_minimizers(software_options)
-  num_runs = software_options.get('num_runs', None)
-
-  if num_runs is None:
-    if 'num_runs' in software_options:
-      options_file = software_options['num_runs']
-      num_runs = options.get_option(options_file=options_file,
-                                    option='num_runs')
-    else:
-      num_runs = options.get_option(option='num_runs')
+    logger.info("Loading minimizers from %s", software_options['software'])
+    minimizers, software = misc.get_minimizers(software_options)
+    num_runs = software_options.get('num_runs', None)
 
     if num_runs is None:
-      num_runs = 5
+        if 'num_runs' in software_options:
+            options_file = software_options['num_runs']
+            num_runs = options.get_option(options_file=options_file,
+                                          option='num_runs')
+        else:
+            num_runs = options.get_option(option='num_runs')
 
-  # create list of paths to all problem definitions in data_dir
-  problem_group = misc.get_problem_files(data_dir)
+        if num_runs is None:
+            num_runs = 5
 
-  results_dir = create_dirs.results(results_dir)
-  group_results_dir = create_dirs.group_results(results_dir, group_name)
+    # create list of paths to all problem definitions in data_dir
+    problem_group = misc.get_problem_files(data_dir)
 
-  user_input = misc.save_user_input(software, minimizers, group_name,
-                                    group_results_dir, use_errors)
+    results_dir = create_dirs.results(results_dir)
+    group_results_dir = create_dirs.group_results(results_dir, group_name)
 
-  prob_results = _benchmark(user_input, problem_group, num_runs)
+    user_input = misc.save_user_input(software, minimizers, group_name,
+                                      group_results_dir, use_errors)
 
-  return prob_results, results_dir
+    prob_results = _benchmark(user_input, problem_group, num_runs)
+
+    return prob_results, results_dir
 
 
 def _benchmark(user_input, problem_group, num_runs=5):
-  """
-  Loops through software and benchmarks each problem within the problem
-  group.
+    """
+    Loops through software and benchmarks each problem within the problem
+    group.
 
-  @param user_input :: all the information specified by the user
-  @param problem_group :: list of paths to problem files in the group
+    @param user_input :: all the information specified by the user
+    @param problem_group :: list of paths to problem files in the group
                           e.g. ['NIST/low_difficulty/file1.dat',
                                 'NIST/low_difficulty/file2.dat',
                                 ...]
-  @param num_runs :: number of times controller.fit() is run to
+    @param num_runs :: number of times controller.fit() is run to
                      generate an average runtime
 
 
-  @returns :: array of result objects, per problem per user_input
-  """
+    @returns :: array of result objects, per problem per user_input
+    """
 
-  parsed_problems = [parse.parse_problem_file(p) for p in problem_group]
+    parsed_problems = [parse.parse_problem_file(p) for p in problem_group]
 
-  if not isinstance(user_input, list):
-    list_prob_results = [per_func
-                         for p in parsed_problems
-                         for per_func in fitbm_one_prob(user_input,
-                                                        p, num_runs)]
+    if not isinstance(user_input, list):
+        list_prob_results = [per_func
+                             for p in parsed_problems
+                             for per_func in fitbm_one_prob(user_input,
+                                                            p, num_runs)]
 
-  else:
-    list_prob_results = [[fitbm_one_prob(u, p, num_runs)
-                          for u in user_input]
-                         for p in parsed_problems]
+    else:
+        list_prob_results = [[fitbm_one_prob(u, p, num_runs)
+                              for u in user_input]
+                             for p in parsed_problems]
 
-    # reorganise loop structure from:
-    # [[[val per minimizer] per function] per input] per problem]
-    # to:
-    # [[val per input per minimizer] per function per problem]
-    list_prob_results = \
-        [[list_prob_results[prob_idx][input_idx][func_idx][minim_idx]
-          for input_idx in range(len(user_input))
-          for minim_idx in range(len(list_prob_results[prob_idx][input_idx][func_idx]))]
-         for prob_idx in range(len(parsed_problems))
-         for func_idx in range(len(list_prob_results[prob_idx][0]))]
+        # reorganise loop structure from:
+        # [[[val per minimizer] per function] per input] per problem]
+        # to:
+        # [[val per input per minimizer] per function per problem]
+        list_prob_results = \
+            [[list_prob_results[prob_idx][input_idx][func_idx][minim_idx]
+              for input_idx in range(len(user_input))
+              for minim_idx
+              in range(len(list_prob_results[prob_idx][input_idx][func_idx]))]
+             for prob_idx in range(len(parsed_problems))
+             for func_idx in range(len(list_prob_results[prob_idx][0]))]
 
-  return list_prob_results
+    return list_prob_results


### PR DESCRIPTION
#### Description of Work

Fixes #257 

Allows FitBenchmarking to calls a minimizer multiple of times and thus calculates an average elapsed time using `timeit`.

#### Testing Instructions

1. Check the accuracy tables are still the same 
2. New timing results are consistent between runs

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
