### PR TITLE
295 notable combinations table

### DIFF
--- a/docs/source/users/index.rst
+++ b/docs/source/users/index.rst
@@ -10,4 +10,5 @@ Welcome to the documentation for the FitBenchmarking software.
     getting_started
     examples
     options
+    notes
 

--- a/docs/source/users/notes.rst
+++ b/docs/source/users/notes.rst
@@ -1,0 +1,52 @@
+.. _notes:
+
+#####
+Notes
+#####
+
+This document is used to detail any known issues or unexpected behaviour
+within the software.
+
+
+************************************
+Problem-Format/Software Combinations
+************************************
+
+Some of the pairings of problem types and software exhibit behavour which may
+be unexpected.
+These are listed in the below table.
+
+.. list-table::
+   :widths: 1 1 3 1 3 1
+   :stub-columns: 1
+   :header-rows: 1
+
+   * - Problem Types \\ Fitting Software
+     - DFOGN
+     - Mantid
+     - RALFit
+     - SASView
+     - Scipy
+   * - Fitbenchmark
+     - None
+     - | This is expected to have a smaller
+       | overhead on evaluating functions,
+       | and so may be faster when compared
+       | to other softwares.
+     - None
+     - | This is known to display a large
+       | amount of exceptions relating to
+       | setting values to inf.
+     - None
+   * - SASView
+     - None
+     - None
+     - None
+     - None
+     - None
+   * - NIST
+     - None
+     - None
+     - None
+     - None
+     - None

--- a/docs/source/users/notes.rst
+++ b/docs/source/users/notes.rst
@@ -51,7 +51,7 @@ When comparing the minimizers of a particular software against a particular type
 
 The stopping criterion of each minimizer is set to the default value. An experienced user can change this.
 
-************************************
-A note on SASView Problem Definition
-************************************
+********************************
+SasView Problem Definition files
+********************************
 In line with Sasview, for problems in the SasView data format, all data with an x value of 0 will be removed from the dataset before fitting. 'x' for SAS data are q (momentum) and q=0 cannot be measured in SAS experiments.

--- a/docs/source/users/notes.rst
+++ b/docs/source/users/notes.rst
@@ -50,3 +50,10 @@ These are listed in the below table.
      - None
      - None
      - None
+
+
+**************************
+SASView Problem Definition
+**************************
+Due to the physical expectation for problems in the SASView data format, all
+data with an x value of 0 will be removed from the dataset before fitting.

--- a/docs/source/users/notes.rst
+++ b/docs/source/users/notes.rst
@@ -51,6 +51,7 @@ These are listed in the below table.
      - None
      - None
 
+The stopping criterion of each minimizer is set to the default value. An experienced user can change this.
 
 **************************
 SASView Problem Definition

--- a/docs/source/users/notes.rst
+++ b/docs/source/users/notes.rst
@@ -12,9 +12,7 @@ within the software.
 Problem-Format/Software Combinations
 ************************************
 
-Some of the pairings of problem types and software exhibit behavour which may
-be unexpected.
-These are listed in the below table.
+When comparing the minimizers of a particular software against a particular type of problem-format files we are not aware of any issues. However, the general problem of comparising minimizers from different software and with different problem-formats - all on truely equal terms - is harder to achieve. In the table below, the cells with a value different from None, show the cases, that we are aware off, where this is still not achieved.
 
 .. list-table::
    :widths: 1 1 3 1 3 1
@@ -53,8 +51,7 @@ These are listed in the below table.
 
 The stopping criterion of each minimizer is set to the default value. An experienced user can change this.
 
-**************************
-SASView Problem Definition
-**************************
-Due to the physical expectation for problems in the SASView data format, all
-data with an x value of 0 will be removed from the dataset before fitting.
+************************************
+A note on SASView Problem Definition
+************************************
+In line with Sasview, for problems in the SasView data format, all data with an x value of 0 will be removed from the dataset before fitting. 'x' for SAS data are q (momentum) and q=0 cannot be measured in SAS experiments.

--- a/docs/source/users/options.rst
+++ b/docs/source/users/options.rst
@@ -18,7 +18,8 @@ These include:
 The software to use in fitting as a string or list of strings.
 Selected softwares will be benchmarked.
 
-Available options are ``"mantid"``, ``"sasview"``, ``"scipy"`` and ``"dfogn"``.
+Available options are ``"dfogn"``, ``"mantid"``, ``""ralfit""``, ``"sasview"``,
+and ``"scipy"``.
 
 ``results_dir``
 ---------------

--- a/docs/source/users/options.rst
+++ b/docs/source/users/options.rst
@@ -30,7 +30,7 @@ If ``None``, a results directory will be created at ``./results``.
 Bool to select whether to use errors in the fitting process or not.
 
 ``color_scale``
---------------
+---------------
 The mapping from relative value to colour in the results table.
 
 This should be in the form of a list of 2-tuples,
@@ -126,6 +126,7 @@ Scipy:
 
 DFO-GN:
   - ``"dfogn"``
+
   Information about this can be found on the
   `DFO-GN documentation
   <http://people.maths.ox.ac.uk/robertsl/dfogn/>`__
@@ -133,6 +134,7 @@ DFO-GN:
 
 RALfit:
   - ``"ralfit"``
+
   Information about this can be found on the
   `RALfit documentation
   <https://github.com/ralna/RALFit>`__
@@ -164,6 +166,7 @@ Available options are ``"abs"``, ``"rel"``, or ``"both"``.
 ``num_runs``
 -------------------
 
-Number of runs is defines how many times FitBenchmarking calls a minimizer and thus calculates an average elapsed time using ``timeit``.
+Number of runs defines how many times FitBenchmarking calls a minimizer and
+calculates an average elapsed time using ``timeit``.
 
 Default set as ``5``.


### PR DESCRIPTION
#### Description of Work

Fixes #295 
Adds table of known combinations which may cause erroneous results:
[notes](https://fitbenchmarking.readthedocs.io/en/295-notable_combinations_table/users/notes.html)

#### Testing Instructions

1. Verify that the new table covers known issues


Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
