### PR TITLE
299 travis notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ dist: xenial
 virtualenv:
   system_site_packages: true
 
+notifications:
+  email:
+    recipients:
+      - support@fitbenchmarking.com
+    on_success: never
+    on_failure: always
+
 stages:
   - name: Tests
   - name: SysTests
@@ -54,6 +61,7 @@ jobs:
           --cov-report term-missing --cov-append
       after_success:
         - coveralls
+  allow_failures:
     - stage: SysTests
       before_script: mantidpython -m mantid.simpleapi || true
       script:


### PR DESCRIPTION
#### Description of Work

Fixes #299 
Adds an email notification.
Sets the systests to optional while they are outdated.


#### Testing Instructions

1. Read though the yaml and the docs [here](https://docs.travis-ci.com/user/notifications#configuring-email-notifications) to verify the notifications. (Unfortunately I don't think this can be tested properly until it has been merged for a day.)
2. Follow up 1 day after merging by checking for an email (if master is failing)

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
