### PR TITLE
Issue #313: Add path on externals install and echo message for user t…

### DIFF
--- a/build/install/mantid.sh
+++ b/build/install/mantid.sh
@@ -22,4 +22,4 @@ sudo apt-get install mantid -y
 
 PYTHONPATH=$PYTHONPATH:/opt/Mantid/lib
 echo "Mantid is now setup for this session."
-echo "To enable mantid in future sessions we recommend adding 'PYTHONPATH=$PYTHONPATH:/opt/Mantid/lib' to your .bashrc file"
+echo "To enable mantid in future sessions we recommend adding 'export PYTHONPATH=$PYTHONPATH:/opt/Mantid/lib' to your .bashrc file"

--- a/build/install/mantid.sh
+++ b/build/install/mantid.sh
@@ -19,3 +19,7 @@ sudo apt-add-repository ppa:mantid/mantid -y
 
 sudo apt-get update
 sudo apt-get install mantid -y
+
+PYTHONPATH=$PYTHONPATH:/opt/Mantid/lib
+echo "Mantid is now setup for this session."
+echo "To enable mantid in future sessions we recommend adding 'PYTHONPATH=$PYTHONPATH:/opt/Mantid/lib' to your .bashrc file"


### PR DESCRIPTION
…o add it to a bashrc file

#### Description of Work

Fixes #313 
Adds new mantid lib location to python path after install and prints a message for the user to add it to their bashrc in order to persist it.


#### Testing Instructions

1. Verify that the message makes sense
2. Verify that tests run (They'll fail when importing mantid if it doesn't work)


Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
