### PR TITLE
Reordering execution runtime

### DIFF
--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -38,32 +38,32 @@ def fitbm_one_prob(problem, options, directory):
     if not isinstance(software, list):
         software = [software]
 
-    for s in software:
-        print("    Software: {}".format(s.upper()))
-        try:
-            minimizers = options.minimizers[s]
-        except KeyError:
-            raise ValueError(
-                'Minimizers could not be found for software: {}'.format(s))
+    for i in range(len(problem.starting_values)):
+        print("    Starting value: {0}/{1}".format(
+            i + 1,
+            len(problem.starting_values)))
+        if len(results) <= i:
+            results.append({})
 
-        controller_cls = ControllerFactory.create_controller(software=s)
-        controller = controller_cls(problem=problem,
-                                    use_errors=options.use_errors)
+        for s in software:
+            print("        Software: {}".format(s.upper()))
+            try:
+                minimizers = options.minimizers[s]
+            except KeyError:
+                raise ValueError(
+                    'Minimizers could not be found for software: {}'.format(s))
 
-        # The controller reformats the data to fit within a start- and end-x
-        # bound
-        # It also estimates errors if not provided.
-        # Copy this back to the problem as it is used in plotting.
-        problem.data_x = controller.data_x
-        problem.data_y = controller.data_y
-        problem.data_e = controller.data_e
+            controller_cls = ControllerFactory.create_controller(software=s)
+            controller = controller_cls(problem=problem,
+                                        use_errors=options.use_errors)
 
-        for i in range(len(controller.starting_values)):
-            print("        Starting value: {0}/{1}".format(
-                i + 1,
-                len(controller.starting_values)))
-            if len(results) <= i:
-                results.append({})
+            # The controller reformats the data to fit within a start- and end-x
+            # bound
+            # It also estimates errors if not provided.
+            # Copy this back to the problem as it is used in plotting.
+            problem.data_x = controller.data_x
+            problem.data_y = controller.data_y
+            problem.data_e = controller.data_e
 
             controller.parameter_set = i
             problem_result, best_fit = benchmark(controller=controller,
@@ -78,7 +78,6 @@ def fitbm_one_prob(problem, options, directory):
                                  group_results_dir=directory)
 
             results[i][s] = problem_result
-
     return results
 
 

--- a/fitbenchmarking/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/fitbenchmark_one_problem.py
@@ -57,8 +57,8 @@ def fitbm_one_prob(problem, options, directory):
             controller = controller_cls(problem=problem,
                                         use_errors=options.use_errors)
 
-            # The controller reformats the data to fit within a start- and end-x
-            # bound
+            # The controller reformats the data to fit within a
+            # start- and end-x bound
             # It also estimates errors if not provided.
             # Copy this back to the problem as it is used in plotting.
             problem.data_x = controller.data_x


### PR DESCRIPTION
#### Description of Work

Fixes #336 

Changes the order of execution so that for each initial value the fitbenchmarking runs through the each software, such that the output to the screen is:
![output](https://user-images.githubusercontent.com/15614849/70130483-8a46be00-1678-11ea-9482-535d4a5c9303.png)

#### Testing Instructions

1. Check that the html pages are consistent. 

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
