### PR TITLE
Improve error messages for failed factory imports

### DIFF
--- a/fitbenchmarking/fitting/controllers/controller_factory.py
+++ b/fitbenchmarking/fitting/controllers/controller_factory.py
@@ -5,6 +5,7 @@ This is used to manage the imports and reduce effort in adding new controllers.
 
 from importlib import import_module
 from inspect import isclass, isabstract, getmembers
+import os
 
 from fitbenchmarking.fitting.controllers.base_controller import Controller
 
@@ -34,10 +35,16 @@ class ControllerFactory:
 
         try:
             module = import_module('.' + module_name, __package__)
-        except ImportError:
-            raise ValueError(
-                'Could not find controller for {}.'.format(software)
-                + 'Check the input is correct and try again.')
+        except ImportError as e:
+            full_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     module_name+'.py'))
+            if os.path.exists(full_path):
+                raise ImportError('This controller cannot be used as '
+                                  'requirements are missing: ' + str(e))
+            else:
+                raise ValueError('Could not find controller for {}. '
+                                 'Check the input is correct and try '
+                                 'again.'.format(software))
 
         classes = getmembers(module, lambda m: (isclass(m)
                                                 and not isabstract(m)

--- a/fitbenchmarking/parsing/parser_factory.py
+++ b/fitbenchmarking/parsing/parser_factory.py
@@ -5,6 +5,7 @@ This is used to manage the imports and reduce effort in adding new parsers.
 
 from importlib import import_module
 from inspect import isclass, isabstract, getmembers
+import os
 
 from fitbenchmarking.parsing.base_parser import Parser
 
@@ -40,11 +41,19 @@ class ParserFactory:
             module_name += l
 
         module_name = '{}_parser'.format(module_name.lower())
+
         try:
             module = import_module('.' + module_name, __package__)
-        except ImportError:
-            raise ValueError('Could not find parser for {}.'.format(filename)
-                             + 'Check the input is correct and try again.')
+        except ImportError as e:
+            full_path = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     module_name+'.py'))
+            if os.path.exists(full_path):
+                raise ImportError('This parser cannot be used as requirements'
+                                  'are missing: ' + str(e))
+            else:
+                raise ValueError('Could not find parser for {}. '
+                                 'Check the input is correct and try '
+                                 'again.'.format(filename))
 
         classes = getmembers(module, lambda m: (isclass(m)
                                                 and not isabstract(m)


### PR DESCRIPTION
#### Description of Work

Fixes #321

Checks if file exists, and if file does exist, this assumes a dependency is missing.
Otherwise it prints the old message.

#### Testing Instructions

1. Break one of the controllers in a way that will report an ImportError (e.g. try `import fitbenchmarking.fake_pkg`) and check the error message.
2. Try to run a controller that does not exist and check the error message

Function: Does the change do what it's supposed to?
Tests: Does it pass? Is there adequate coverage for new code?
Style: Is the coding style consistent? Is anything overly confusing?
Documentation: Is there a suitable change to documentation for this change?
