### PR TITLE
Add defaults if no x, y, e passed in

### DIFF
--- a/fitbenchmarking/parsing/fitting_problem.py
+++ b/fitbenchmarking/parsing/fitting_problem.py
@@ -157,6 +157,11 @@ class FittingProblem:
                  given parameters
         :rtype: numpy array
         """
+        if x is None and y is None and e is None:
+            x = self.data_x
+            y = self.data_y
+            e = self.data_e
+
         r = self.eval_r(params=params, x=x, y=y, e=e)
         return np.dot(r, r)
 


### PR DESCRIPTION
#### Description of Work

Fixes #364 


#### Testing Instructions

1. run for a solver that uses eval_r_norm (minuit or gsl), and check behaviour is as expected.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
