### PR TITLE
Issue #399: Make remaining absolute links relative and remove "file:///"

### DIFF
--- a/fitbenchmarking/cli/main.py
+++ b/fitbenchmarking/cli/main.py
@@ -96,6 +96,8 @@ def run(problem_sets, options_file=''):
                                          options=options)
 
         print('\nCompleted benchmarking for {} problem set\n'.format(sub_dir))
+        group_results_dir = os.path.relpath(path=group_results_dir,
+                                            start=options.results_dir)
         result_dir.append(group_results_dir)
         groups.append(label)
 

--- a/fitbenchmarking/results_processing/plots.py
+++ b/fitbenchmarking/results_processing/plots.py
@@ -175,7 +175,7 @@ class Plot(object):
 
         # Make sure line wont be replaced by resetting line_plot
         self.line_plot = None
-        return file_name
+        return file
 
     def plot_fit(self, minimizer, params):
         """

--- a/fitbenchmarking/results_processing/visual_pages.py
+++ b/fitbenchmarking/results_processing/visual_pages.py
@@ -131,9 +131,6 @@ def get_figure_paths(result, count):
             output.append('')
         else:
             path = os.path.join(figures_dir, link)
-            # If OS is Windows, then need to add prefix 'file:///'
-            if os.name == 'nt':
-                path = 'file:///' + path
             output.append(path)
 
     return output[0], output[1]


### PR DESCRIPTION
#### Description of Work

Fixes #399 

Makes results_index.html use relative links so they work on windows and Linux.
Removes "file:///" from the plots as this is not needed for relative links.


#### Testing Instructions

1. Run FitBM and check that links work on windows


Function: Does the change do what it's supposed to?
Tests: Does it pass? Is there adequate coverage for new code?
Style: Is the coding style consistent? Is anything overly confusing?
Documentation: Is there a suitable change to documentation for this change?