### PR TITLE
Missing ini file

### DIFF
--- a/fitbenchmarking/cli/main.py
+++ b/fitbenchmarking/cli/main.py
@@ -59,8 +59,14 @@ def run(problem_sets, options_file=''):
     current_path = os.path.abspath(os.path.curdir)
     if options_file != '':
         # Read custom minimizer options from file
-        options_file = glob.glob(options_file)
-        options = Options(options_file)
+        glob_options_file = glob.glob(options_file)
+        if glob_options_file == [] or not options_file.endswith(".ini"):
+            raise RuntimeError('Error in user input options file. Please check'
+                               'that the file exist and has an .ini '
+                               'extension, current path to file is '
+                               '{}'.format(options_file))
+        else:
+            options = Options(glob_options_file)
     else:
         options = Options()
     groups = []

--- a/fitbenchmarking/cli/tests/test_main.py
+++ b/fitbenchmarking/cli/tests/test_main.py
@@ -24,6 +24,16 @@ class TestExampleScripts(unittest.TestCase):
     def tearDownClass(self):
         os.chdir(self.cwd)
 
+    def test_run_with_wrong_option_file_extension(self):
+        with self.assertRaises(RuntimeError):
+            main.run(['examples/benchmark_problems/simple_tests'],
+                     options_file='README.md')
+
+    def test_run_with_wrong_option_file(self):
+        with self.assertRaises(RuntimeError):
+            main.run(['examples/benchmark_problems/simple_tests'],
+                     options_file='options_template.ini')
+
     def test_run_with_options(self):
         main.run(['examples/benchmark_problems/simple_tests'],
                  options_file='examples/options_template.ini')

--- a/fitbenchmarking/systests/test_regression.py
+++ b/fitbenchmarking/systests/test_regression.py
@@ -34,7 +34,7 @@ class TestRegression(TestCase):
         opts.software = sorted(opts.minimizers.keys())
         opts.results_dir = os.path.join(os.path.dirname(__file__), 'results')
 
-        opt_file = tempfile.NamedTemporaryFile()
+        opt_file = tempfile.NamedTemporaryFile(suffix='.ini')
         opts.write(opt_file.name)
 
         problem = os.path.abspath(os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
#### Description of Work

Fixes #374 

Checks to see if input options file exists and that it has the right extension.

#### Testing Instructions

1. Check a `RuntimeError` is raised when given a wrong `ini` file location.
1. Check a `RuntimeError` is raised when the given file doesn't have an `ini` extension. 

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
