### PR TITLE
Remove extra third party output

### DIFF
--- a/fitbenchmarking/core/fitbenchmark_one_problem.py
+++ b/fitbenchmarking/core/fitbenchmark_one_problem.py
@@ -10,6 +10,7 @@ import warnings
 
 from fitbenchmarking.controllers.controller_factory import ControllerFactory
 from fitbenchmarking.utils import fitbm_result
+from fitbenchmarking.utils import output_grabber
 
 
 def fitbm_one_prob(problem, options):
@@ -26,7 +27,7 @@ def fitbm_one_prob(problem, options):
                containing the fit information
     :rtype: list
     """
-
+    grabbed_output = output_grabber.OutputGrabber()
     results = []
 
     software = options.software
@@ -47,11 +48,11 @@ def fitbm_one_prob(problem, options):
             except KeyError:
                 raise ValueError(
                     'Minimizers could not be found for software: {}'.format(s))
-
-            controller_cls = ControllerFactory.create_controller(software=s)
-            controller = controller_cls(problem=problem,
-                                        use_errors=options.use_errors)
-
+            with grabbed_output:
+                controller_cls = ControllerFactory.create_controller(
+                    software=s)
+                controller = controller_cls(problem=problem,
+                                            use_errors=options.use_errors)
             # The controller reformats the data to fit within a
             # start- and end-x bound
             # It also estimates errors if not provided.
@@ -85,6 +86,8 @@ def benchmark(controller, minimizers, options):
               minimizer
     :rtype: list
     """
+    grabbed_output = output_grabber.OutputGrabber()
+
     results_problem = []
     num_runs = options.num_runs
     for minimizer in minimizers:
@@ -93,12 +96,13 @@ def benchmark(controller, minimizers, options):
         controller.minimizer = minimizer
 
         try:
-            # Calls timeit repeat with repeat = num_runs and number = 1
-            runtime_list = \
-                timeit.Timer(setup=controller.prepare,
-                             stmt=controller.fit).repeat(num_runs, 1)
-            runtime = sum(runtime_list) / num_runs
-            controller.cleanup()
+            with grabbed_output:
+                # Calls timeit repeat with repeat = num_runs and number = 1
+                runtime_list = \
+                    timeit.Timer(setup=controller.prepare,
+                                 stmt=controller.fit).repeat(num_runs, 1)
+                runtime = sum(runtime_list) / num_runs
+                controller.cleanup()
         # Catching all exceptions as this means runtime cannot be calculated
         # pylint: disable=broad-except
         except Exception as excp:

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -10,6 +10,7 @@ from fitbenchmarking.utils.logging_setup import logger
 
 from fitbenchmarking.parsing.parser_factory import parse_problem_file
 from fitbenchmarking.utils import misc
+from fitbenchmarking.utils import output_grabber
 from fitbenchmarking.core.fitbenchmark_one_problem import fitbm_one_prob
 
 
@@ -33,6 +34,7 @@ def fitbenchmark_group(group_name, options, data_dir):
               the problem group and the location of the results
     :rtype: tuple(list, str)
     """
+    grabbed_output = output_grabber.OutputGrabber()
 
     # Extract problem definitions
     problem_group = misc.get_problem_files(data_dir)
@@ -40,7 +42,9 @@ def fitbenchmark_group(group_name, options, data_dir):
     results = []
     template_prob_name = " Running data from: {}"
     for i, p in enumerate(problem_group):
-        parsed_problem = parse_problem_file(p)
+        with grabbed_output:
+            parsed_problem = parse_problem_file(p)
+
         decorator = '#' * (len(template_prob_name) +
                            len(parsed_problem.name) + 4)
         tmp_prob_name = template_prob_name.format(parsed_problem.name)

--- a/fitbenchmarking/utils/output_grabber.py
+++ b/fitbenchmarking/utils/output_grabber.py
@@ -56,8 +56,11 @@ class OutputGrabber(object):
         Read the stream data (one byte at a time)
         and save the text in `capturedtext`.
         """
+        self.pipe_out, self.pipe_in = os.pipe()
         while True:
             char = os.read(self.pipe_out, 1)
             if not char or self.escape_char in char:
                 break
             self.capturedtext += char
+        os.close(self.pipe_in)
+        os.close(self.pipe_out)

--- a/fitbenchmarking/utils/output_grabber.py
+++ b/fitbenchmarking/utils/output_grabber.py
@@ -43,6 +43,8 @@ class OutputGrabber(object):
         # the escape character:
         self.origstream.flush()
 
+        # Reads the output and stores it in capturedtext
+        self.readOutput()
         # Close the pipe:
         os.close(self.pipe_in)
         os.close(self.pipe_out)
@@ -56,11 +58,8 @@ class OutputGrabber(object):
         Read the stream data (one byte at a time)
         and save the text in `capturedtext`.
         """
-        self.pipe_out, self.pipe_in = os.pipe()
         while True:
             char = os.read(self.pipe_out, 1)
             if not char or self.escape_char in char:
                 break
             self.capturedtext += char
-        os.close(self.pipe_in)
-        os.close(self.pipe_out)

--- a/fitbenchmarking/utils/output_grabber.py
+++ b/fitbenchmarking/utils/output_grabber.py
@@ -1,0 +1,63 @@
+import os
+import sys
+
+
+class OutputGrabber(object):
+    """
+    Class used to grab standard output or another stream.
+    """
+    escape_char = "\b"
+
+    def __init__(self):
+
+        self.origstream = sys.stdout
+        self.origstreamfd = self.origstream.fileno()
+        self.capturedtext = ""
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.stop()
+
+    def start(self):
+        """
+        Start capturing the stream data.
+        """
+        # Create a pipe so the stream can be captured:
+        self.pipe_out, self.pipe_in = os.pipe()
+        self.capturedtext = ""
+        # Save a copy of the stream:
+        self.streamfd = os.dup(self.origstreamfd)
+        # Replace the original stream with our write pipe:
+        os.dup2(self.pipe_in, self.origstreamfd)
+
+    def stop(self):
+        """
+        Stop capturing the stream data and save the text in `capturedtext`.
+        """
+        # Print the escape character to make the readOutput method stop:
+        self.origstream.write(self.escape_char)
+        # Flush the stream to make sure all our data goes in before
+        # the escape character:
+        self.origstream.flush()
+
+        # Close the pipe:
+        os.close(self.pipe_in)
+        os.close(self.pipe_out)
+        # Restore the original stream:
+        os.dup2(self.streamfd, self.origstreamfd)
+        # Close the duplicate stream:
+        os.close(self.streamfd)
+
+    def readOutput(self):
+        """
+        Read the stream data (one byte at a time)
+        and save the text in `capturedtext`.
+        """
+        while True:
+            char = os.read(self.pipe_out, 1)
+            if not char or self.escape_char in char:
+                break
+            self.capturedtext += char

--- a/fitbenchmarking/utils/tests/test_output_grabber.py
+++ b/fitbenchmarking/utils/tests/test_output_grabber.py
@@ -1,0 +1,17 @@
+from __future__ import (absolute_import, division, print_function)
+import unittest
+
+from fitbenchmarking.utils.output_grabber import OutputGrabber
+
+
+class OutputGrabberTests(unittest.TestCase):
+
+    def test_correct_output(self):
+        output_string = 'This is the correct output string\nSecond line'
+        output = OutputGrabber()
+        with output:
+            print(output_string)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fitbenchmarking/utils/tests/test_output_grabber.py
+++ b/fitbenchmarking/utils/tests/test_output_grabber.py
@@ -11,6 +11,17 @@ class OutputGrabberTests(unittest.TestCase):
         output = OutputGrabber()
         with output:
             print(output_string)
+        # print adds an extra \n
+        assert output.capturedtext == output_string + "\n"
+
+    def test_incorrect_output(self):
+        output_string = 'This is the correct output string\nSecond line'
+        incorrect_output_sting = 'This is the incorrect string'
+        output = OutputGrabber()
+        with output:
+            print(output_string)
+        # print adds an extra \n
+        assert output.capturedtext != incorrect_output_sting + "\n"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Description of Work

Fixes #168 

Adds a output grabber based on [this.](https://stackoverflow.com/questions/24277488/in-python-how-to-capture-the-stdout-from-a-c-shared-library-to-a-variable?rq=1)

#### Testing Instructions

1. Check that the third party output is removed.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
