### PR TITLE
First attempt set up Windows CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'windows-latest'
 strategy:
   matrix:
  #   Python27:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,37 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+strategy:
+  matrix:
+ #   Python27:
+ #     python.version: '2.7'
+ #   Python35:
+ #     python.version: '3.5'
+    Python36:
+      python.version: '3.6'
+    Python37:
+      python.version: '3.7'
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+  displayName: 'Use Python $(python.version)'
+
+- script: |
+    python -m pip install
+#    python -m pip install --upgrade pip
+#    pip install -r requirements.txt
+  displayName: 'Install dependencies'
+
+#- script: |
+#    pip install pytest pytest-azurepipelines
+#    pytest
+#  displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,6 @@ pool:
   vmImage: 'windows-latest'
 strategy:
   matrix:
- #   Python27:
- #     python.version: '2.7'
- #   Python35:
- #     python.version: '3.5'
     Python36:
       python.version: '3.6'
     Python37:
@@ -31,7 +27,7 @@ steps:
 #    pip install -r requirements.txt
   displayName: 'Install dependencies'
 
-#- script: |
-#    pip install pytest pytest-azurepipelines
-#    pytest
-#  displayName: 'pytest'
+- script: |
+    pip install pytest pytest-azurepipelines
+    pytest fitbenchmarking\utils\tests\test_logger.py
+  displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,6 @@
-# Python package
-# Create and test a Python package on multiple Python versions.
-# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+# CI for Windows
+# Here not repeating LINTING and similar done with Travis (only this may make sense later)
+# For info syntax used in this file see: https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 trigger:
 - master
@@ -22,13 +21,13 @@ steps:
   displayName: 'Use Python $(python.version)'
 
 - script: |
+    # note sure if needed / relevant but here upgrade pip first 
+    python -m pip install --upgrade pip
     pip install .
-#    python -m pip install --upgrade pip
-#    pip install -r requirements.txt
-  displayName: 'Install dependencies'
+  displayName: 'Install FitBenchmarking'
 
 - script: |
     pip install pytest pytest-azurepipelines
     pytest fitbenchmarking\utils\tests\test_logger.py
-    pytest fitbenchmarking\utils\tests\test_fitbm_result.py
-  displayName: 'pytest'
+    # pytest fitbenchmarking\utils\tests\test_fitbm_result.py (breaks in first azure pipeline install)
+  displayName: 'pytest utils tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
   displayName: 'Use Python $(python.version)'
 
 - script: |
-    python -m pip install
+    pip install .
 #    python -m pip install --upgrade pip
 #    pip install -r requirements.txt
   displayName: 'Install dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,13 +21,11 @@ steps:
   displayName: 'Use Python $(python.version)'
 
 - script: |
-    # note sure if needed / relevant but here upgrade pip first 
-    python -m pip install --upgrade pip
     pip install .
   displayName: 'Install FitBenchmarking'
 
 - script: |
     pip install pytest pytest-azurepipelines
     pytest fitbenchmarking\utils\tests\test_logger.py
-    # pytest fitbenchmarking\utils\tests\test_fitbm_result.py (breaks in first azure pipeline install)
+#    pytest fitbenchmarking\utils\tests\test_fitbm_result.py (breaks in first azure pipeline install)
   displayName: 'pytest utils tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,4 +30,5 @@ steps:
 - script: |
     pip install pytest pytest-azurepipelines
     pytest fitbenchmarking\utils\tests\test_logger.py
+    pytest fitbenchmarking\utils\tests\test_fitbm_result.py
   displayName: 'pytest'


### PR DESCRIPTION
 Created first Windows CI setup with Azure pipelines.

CI here builds FitBenchmarking and run one of its tests.

More widely as reported elsewhere Windows support of FitBenchmarking been broken. This is first step to get CI support setup for Windows to avoid Windows support is broken sometime later again.

Fixes #171

##Test
* Check builds pass
* Check that has permission (other than me) to access Azure build

