### PR TITLE
Updating first example docs

### DIFF
--- a/docs/source/users/running.rst
+++ b/docs/source/users/running.rst
@@ -10,7 +10,7 @@ directory along with a template for passing in options.
 To run with any of these problem sets, you should pass the path to the
 `fitbenchmarking` command.
 
-  e.g ``fitbenchmarking examples/benchmark_problems/NIST/high_difficulty``
+  e.g ``fitbenchmarking examples/benchmark_problems/NIST/low_difficulty``
 
 An options file can also be passed with the ``-o`` argument.
 The template in `examples` is heavily documented and serves as a good

--- a/docs/source/users/running.rst
+++ b/docs/source/users/running.rst
@@ -10,7 +10,7 @@ directory along with a template for passing in options.
 To run with any of these problem sets, you should pass the path to the
 `fitbenchmarking` command.
 
-  e.g ``fitbenchmarking examples/benchmarking_problems/simple_tests``
+  e.g ``fitbenchmarking examples/benchmark_problems/NIST/high_difficulty``
 
 An options file can also be passed with the ``-o`` argument.
 The template in `examples` is heavily documented and serves as a good

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -98,7 +98,7 @@ def loop_over_benchmark_problems(problem_group, options):
             with grabbed_output:
                 parsed_problem = parse_problem_file(p, options)
                 parsed_problem.correct_data()
-        except MissingSoftwareError as e:
+        except Exception as e:
             info_str = " Could not run data from: {} {}/{}".format(
                 p, i + 1, len(problem_group))
             LOGGER.warn(e)

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -119,11 +119,11 @@ def loop_over_benchmark_problems(problem_group, options):
     # raise an exception and the tables will produce errors if they run.
     if results == []:
         message = "The user chosen options and/or problem setup resulted in " \
-                  " all minimizers and/or parsers raising an exception. " \
-                  " This is likely due to the way `algorithm_type` was set " \
-                  " in the options or the selected problem set requires " \
-                  " additional software to be installed. Please review your " \
-                  " options setup and/or problem set then re-run " \
+                  "all minimizers and/or parsers raising an exception. " \
+                  "This is likely due to the way `algorithm_type` was set " \
+                  "in the options or the selected problem set requires " \
+                  "additional software to be installed. Please review your " \
+                  "options setup and/or problem set then re-run " \
                   "FitBenmarking."
         raise NoResultsError(message)
 

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark.py
@@ -160,23 +160,6 @@ class BenchmarkTests(unittest.TestCase):
         self.shared_tests(expected_names, expected_unselected_minimzers,
                           expected_minimzers)
 
-    @mock.patch('{}.loop_over_benchmark_problems'.format(FITTING_DIR))
-    def test_check_no_results_produced(self, loop_over_benchmark_problems):
-        """
-        Checks benchmarking raises an error when no results are produced
-        """
-
-        results = []
-        problem_fails = []
-        expected_unselected_minimzers = {"scipy": []}
-        expected_minimzers = copy.copy(self.all_minimzers)
-        loop_over_benchmark_problems.return_value = \
-            (results, problem_fails, expected_unselected_minimzers,
-             expected_minimzers)
-        with self.assertRaises(NoResultsError):
-            _, _, _ = \
-                benchmark(self.options, self.default_parsers_dir)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark_problems.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark_problems.py
@@ -9,7 +9,7 @@ import unittest
 import mock
 
 from fitbenchmarking import mock_problems
-from fitbenchmarking.utils import fitbm_result
+from fitbenchmarking.utils import fitbm_result, exceptions
 from fitbenchmarking.core.fitting_benchmarking import \
     loop_over_benchmark_problems
 from fitbenchmarking.parsing.parser_factory import parse_problem_file
@@ -134,13 +134,26 @@ class LoopOverBenchmarkProblemsTests(unittest.TestCase):
         self.problem_fails = ['Random_failed_problem_1',
                               'Random_failed_problem_2']
         loop_over_starting_values.side_effect = self.mock_func_call
-        self.problem_group = []
         self.problem_group = [os.path.join(self.default_parsers_dir,
                                            "cubic.dat")]
 
         expected_problem_fails = self.problem_fails
         expected_list_length = len(self.list_results)
         self.shared_tests(expected_list_length, expected_problem_fails)
+
+    @mock.patch('{}.loop_over_starting_values'.format(FITTING_DIR))
+    def test_check_no_results_produced(self, loop_over_starting_values):
+        """
+        Checks that multiple failed problems are reported correctly
+        """
+        loop_over_starting_values.side_effect = self.mock_func_call
+        problem_group = [os.path.join(self.default_parsers_dir,
+                                      "META.txt")]
+
+        with self.assertRaises(exceptions.NoResultsError):
+            _, _, _ = \
+                loop_over_benchmark_problems(problem_group,
+                                             self.options)
 
 
 if __name__ == "__main__":

--- a/fitbenchmarking/parsing/nist_parser.py
+++ b/fitbenchmarking/parsing/nist_parser.py
@@ -57,11 +57,15 @@ class NISTParser(Parser):
             nist_func_definition(function=fitting_problem.equation,
                                  param_names=starting_values[0].keys())
         fitting_problem.format = "nist"
+        try:
+            jacobian = self._parse_jacobian(name)
+            fitting_problem.jacobian = \
+                nist_jacobian_definition(jacobian=jacobian,
+                                         param_names=starting_values[0].keys())
+        except NoJacobianError:
+            LOGGER.warn("WARNING: Could not find analytic Jacobian "
+                        "information for {} problem".format(name))
 
-        jacobian = self._parse_jacobian(name)
-        fitting_problem.jacobian = \
-            nist_jacobian_definition(jacobian=jacobian,
-                                     param_names=starting_values[0].keys())
         return fitting_problem
 
     def _parse_jacobian(self, name):


### PR DESCRIPTION
#### Description of Work

Fixes #589 

Updates the first example in the docs to be from the NIST problem set. Also, allows problem sets with different problem types (`mantid`, `NIST`, etc) to be run without errors if an external package is not installed. 

#### Testing Instructions

1. Check new first example runs without any warnings for default installation.
2. Check `simple_tests` run with just a warning for the mantid problems
3. Check a Mantid data set (`Neutron` or `Muon`) raise a `FitBenchmarking ran with no results` error.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
