### PR TITLE
Update check_attributes function in base controller

### DIFF
--- a/fitbenchmarking/controllers/base_controller.py
+++ b/fitbenchmarking/controllers/base_controller.py
@@ -159,12 +159,17 @@ class Controller:
                         'type. Expected "{}", got {}.'.format(
                             attr_name, attr_type, type(attr)))
             else:
-                if any(numpy.isnan(n) or numpy.isinf(n) for n in attr):
-                    raise ControllerAttributeError(
-                        'Attribute "{}" in the controller is not the expected '
-                        'numpy ndarray of floats. Expected a list or '
-                        'numpy ndarray of floats, got {}'.format(attr_name,
-                                                                 attr))
+                # Mantid multifit produces final params as a list of final
+                # params.
+                if not self.problem.multifit:
+                    attr = [attr]
+                for a in attr:
+                    if any(numpy.isnan(n) or numpy.isinf(n) for n in a):
+                        raise ControllerAttributeError(
+                            'Attribute "{}" in the controller is not the '
+                            'expected numpy ndarray of floats. Expected a '
+                            'list or numpy ndarray of floats, got '
+                            '{}'.format(attr_name, attr))
 
     @abstractmethod
     def jacobian_information(self):

--- a/fitbenchmarking/controllers/base_controller.py
+++ b/fitbenchmarking/controllers/base_controller.py
@@ -159,7 +159,7 @@ class Controller:
                         'type. Expected "{}", got {}.'.format(
                             attr_name, attr_type, type(attr)))
             else:
-                if all(numpy.isnan(n) or numpy.isinf(n) for n in attr):
+                if any(numpy.isnan(n) or numpy.isinf(n) for n in attr):
                     raise ControllerAttributeError(
                         'Attribute "{}" in the controller is not the expected '
                         'numpy ndarray of floats. Expected a list or '

--- a/fitbenchmarking/controllers/base_controller.py
+++ b/fitbenchmarking/controllers/base_controller.py
@@ -3,6 +3,7 @@ Implements the base class for the fitting software controllers.
 """
 
 from abc import ABCMeta, abstractmethod
+import numpy
 
 from fitbenchmarking.utils.exceptions import ControllerAttributeError, \
     UnknownMinimizerError
@@ -147,15 +148,23 @@ class Controller:
         A helper function which checks all required attributes are set
         in software controllers
         """
-        values = {'_flag': int}
+        values = {'_flag': int, 'final_params': numpy.ndarray}
 
         for attr_name, attr_type in values.items():
             attr = getattr(self, attr_name)
-            if not isinstance(attr, attr_type):
-                raise ControllerAttributeError(
-                    'Attribute "{}" in the controller is not the expected '
-                    'type. Expected "{}", got {}.'.format(
-                        attr_name, attr_type, type(attr)))
+            if attr_type != numpy.ndarray:
+                if not isinstance(attr, attr_type):
+                    raise ControllerAttributeError(
+                        'Attribute "{}" in the controller is not the expected '
+                        'type. Expected "{}", got {}.'.format(
+                            attr_name, attr_type, type(attr)))
+            else:
+                if all(numpy.isnan(n) or numpy.isinf(n) for n in attr):
+                    raise ControllerAttributeError(
+                        'Attribute "{}" in the controller is not the expected '
+                        'numpy ndarray of floats. Expected a list or '
+                        'numpy ndarray of floats, got {}'.format(attr_name,
+                                                                 attr))
 
     @abstractmethod
     def jacobian_information(self):

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -202,10 +202,10 @@ class BaseControllerTests(TestCase):
                                 attribute
         """
         controller = DummyController(self.problem)
-
         with self.assertRaises(exceptions.ControllerAttributeError):
             controller.check_attributes()
         controller.flag = 1
+        controller.final_params = [1]
         controller.check_attributes()
 
     def test_check_valid_flag(self):
@@ -213,6 +213,8 @@ class BaseControllerTests(TestCase):
         BaseSoftwareController: Test flag setting with valid values
         """
         controller = DummyController(self.problem)
+        controller.final_params = [1]
+
         for flag in [0, 1, 2, 3]:
             controller.flag = flag
 
@@ -221,8 +223,29 @@ class BaseControllerTests(TestCase):
         BaseSoftwareController: Test flag setting with invalid values
         """
         controller = DummyController(self.problem)
+        controller.final_params = [1, 2, 3, 4, 5]
         with self.assertRaises(exceptions.ControllerAttributeError):
             controller.flag = 10
+
+    def test_check_final_params_attr(self):
+        """
+        BaseSoftwareController: Test check_attributes function for final_params
+                                attribute
+        """
+        controller = DummyController(self.problem)
+        controller.final_params = [1, 2, 3, 4, 5]
+        controller.flag = 3
+        controller.check_attributes()
+
+    def test_check_invalid_final_params(self):
+        """
+        BaseSoftwareController: Test final_params setting with invalid values
+        """
+        controller = DummyController(self.problem)
+        controller.flag = 1
+        controller.final_params = [1, np.inf]
+        with self.assertRaises(exceptions.ControllerAttributeError):
+            controller.check_attributes()
 
     def test_validate_minimizer_true(self):
         controller = DummyController(self.problem)

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -347,6 +347,7 @@ def loop_over_jacobians(controller, options, grabbed_output):
                                 num_runs, 1)
                         runtime = sum(runtime_list) / num_runs
                         controller.cleanup()
+                        controller.check_attributes()
                 # Catching all exceptions as this means runtime cannot be
                 # calculated
                 # pylint: disable=broad-except
@@ -361,8 +362,6 @@ def loop_over_jacobians(controller, options, grabbed_output):
 
                     chi_sq = np.inf if not problem.multifit \
                         else [np.inf] * len(controller.data_x)
-
-                controller.check_attributes()
 
                 if controller.flag <= 2:
                     ratio = np.max(runtime_list) / np.min(runtime_list)


### PR DESCRIPTION
#### Description of Work

Fixes #588 

Adds `final_params` to the base controller function `check_attributes` to check whether the elements in the numpy ndarray of  `final_params` are not `nan` or `inf`.

#### Testing Instructions

1. Check that the exception is not raised, the easiest way to do this is to run `scipy` software with all default minimizers and `SLSQP`.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
