### PR TITLE
Adds tests docs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,7 @@ def pytest_addoption(parser):
     """
     parser.addoption(
         "--test-type", action="store", default="all", type=str,
-        choices=['all', 'default', 'external']
+        choices=['all', 'default']
     )
 
 

--- a/docs/source/users/index.rst
+++ b/docs/source/users/index.rst
@@ -15,5 +15,6 @@ the FitBenchmarking software.
     output/index
     options/index
     problem_definition_files/index
+    tests
     notes
 

--- a/docs/source/users/tests.rst
+++ b/docs/source/users/tests.rst
@@ -1,0 +1,39 @@
+.. _tests:
+
+#####################
+FitBenchmarking tests
+#####################
+
+To run both the ``unit`` and ``system`` tests for FitBenchmarking you will need to install ``pytest>=3.6``. We have split the tests into two categories:
+
+* ``default``: denotes all tests that use ``pip`` installable :ref:`software packages<getting-started>`,
+* ``all``: denotes all test.
+
+Unit tests
+----------
+
+Each module directory in FitBenchmarking (e.g. ``controllers``) contains a test folder which has the ``unit`` tests for that module. One can run the tests for a module by:
+
+.. code-block:: bash
+
+   pytest fitbenchmarking/<MODULE_DIR> --test-type <TEST_TYPE>
+
+where <TEST_TYPE> is either ``default`` or ``all``. If ``--test-type`` argument is not given the default is ``all``
+
+System tests
+------------
+
+System tests can be found in the ``systests`` directory in FitBenchmarking. As with the unit tests, these can be run via:
+
+.. code-block:: bash
+
+   pytest fitbenchmarking/systests --test-type <TEST_TYPE>
+
+
+.. warning::
+   The expected results directory in the ``systests`` directory are generated to check consistency in our automated tests via `Travis CI <https://travis-ci.org/>`__. This is done by checking the text output of the tables are consistent, and therefore, they might not pass on your specific operating system due to, for example, different software package versions.
+
+Travis CI tests
+---------------
+
+The scripts that are used our automated tests via `Travis CI <https://travis-ci.org/>`__ are located in the ``travis`` folder. These give an example of how to run both the unit and system tests within FitBenchmarking.

--- a/docs/source/users/tests.rst
+++ b/docs/source/users/tests.rst
@@ -1,13 +1,13 @@
 .. _tests:
 
 #####################
-FitBenchmarking tests
+FitBenchmarking Tests
 #####################
 
-To run both the ``unit`` and ``system`` tests for FitBenchmarking you will need to install ``pytest>=3.6``. We have split the tests into two categories:
+The tests for FitBenchmarking require ``pytest>=3.6``. We have split the tests into two categories:
 
-* ``default``: denotes all tests that use ``pip`` installable :ref:`software packages<getting-started>`,
-* ``all``: denotes all test.
+* ``default``: denotes tests involving ``pip`` installable :ref:`software packages<getting-started>`,
+* ``all``: in addition to ``default``, also runs tests on :ref:`external packages <external-instructions>`.
 
 Unit tests
 ----------
@@ -31,7 +31,7 @@ System tests can be found in the ``systests`` directory in FitBenchmarking. As w
 
 
 .. warning::
-   The expected results directory in the ``systests`` directory are generated to check consistency in our automated tests via `Travis CI <https://travis-ci.org/>`__. This is done by checking the text output of the tables are consistent, and therefore, they might not pass on your specific operating system due to, for example, different software package versions.
+   The files in the expected results subdirectory of the ``systests`` directory are generated to check consistency in our automated tests via `Travis CI <https://travis-ci.org/>`__.  They might not pass on your local operating system due to, for example, different software package versions being installed.
 
 Travis CI tests
 ---------------

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -122,7 +122,6 @@ class ControllerSharedTesting:
         assert controller.flag == 2
 
 
-@pytest.mark.skipif("TEST_TYPE == 'external'")
 class BaseControllerTests(TestCase):
     """
     Tests for base software controller class methods.
@@ -263,7 +262,6 @@ class BaseControllerTests(TestCase):
             controller.validate_minimizer(minimizer, algorithm_type)
 
 
-@pytest.mark.skipif("TEST_TYPE == 'external'")
 class DefaultControllerTests(TestCase):
     """
     Tests for each controller class
@@ -520,7 +518,7 @@ class FactoryTests(TestCase):
     """
     Tests for the ControllerFactory
     """
-    @pytest.mark.skipif("TEST_TYPE == 'external'")
+
     def test_default_imports(self):
         """
         Test that the factory returns the correct default class for inputs

--- a/fitbenchmarking/parsing/tests/test_parsers.py
+++ b/fitbenchmarking/parsing/tests/test_parsers.py
@@ -58,8 +58,6 @@ def generate_test_cases():
         formats = ['cutest', 'nist', 'fitbenchmark']
     elif TEST_TYPE == "default":
         formats = ['nist']
-    elif TEST_TYPE == "external":
-        formats = ['cutest', 'fitbenchmark']
 
     # create list of test_cases
     expected_dir = os.listdir(os.path.join(test_dir, 'expected'))

--- a/fitbenchmarking/systests/test_regression.py
+++ b/fitbenchmarking/systests/test_regression.py
@@ -104,7 +104,6 @@ class TestRegressionAll(TestCase):
         self.assertListEqual([], diff, msg)
 
 
-@pytest.mark.skipif("TEST_TYPE == 'external'")
 @pytest.mark.skipif("TEST_TYPE == 'all'")
 class TestRegressionDefault(TestCase):
     """


### PR DESCRIPTION
#### Description of Work

Fixes #648 

Adds documentation for FitBenchmarking tests and splits the tests into two options `all` and `default` tests.

#### Testing Instructions

1. Check the docs make are clear
2. Check the tests pass

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
