### PR TITLE
Updating default minimizers in options

### DIFF
--- a/fitbenchmarking/systests/test_regression.py
+++ b/fitbenchmarking/systests/test_regression.py
@@ -208,6 +208,7 @@ def setup_options(multifit=False):
         opts.minimizers = {k: [v[0]] for k, v in opts.minimizers.items()}
         opts.software = sorted(opts.minimizers.keys())
     else:
+        opts.software = ['bumps', 'dfo', 'minuit', 'scipy', 'scipy_ls']
         opts.minimizers = {s: [opts.minimizers[s][0]] for s in opts.software}
 
     opts.results_dir = os.path.join(os.path.dirname(__file__), 'results')

--- a/fitbenchmarking/utils/options.py
+++ b/fitbenchmarking/utils/options.py
@@ -84,7 +84,7 @@ class Options(object):
     DEFAULT_FITTING = \
         {'num_runs': 5,
          'algorithm_type': 'all',
-         'software': ['bumps', 'dfo', 'minuit', 'scipy', 'scipy_ls'],
+         'software': ['scipy', 'scipy_ls'],
          'use_errors': True,
          'jac_method': ['scipy']}
     DEFAULT_JACOBIAN = \

--- a/fitbenchmarking/utils/tests/test_options_fitting.py
+++ b/fitbenchmarking/utils/tests/test_options_fitting.py
@@ -41,7 +41,7 @@ class FittingOptionTests(unittest.TestCase):
         """
         Checks software default
         """
-        expected = ['bumps', 'dfo', 'minuit', 'scipy', 'scipy_ls']
+        expected = ['scipy', 'scipy_ls']
         actual = self.options.software
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
#### Description of Work

Fixes #656 
Fixes #607

Sets the default minimizers to be `scipy` and `scipy_ls`.

#### Testing Instructions

1. Check tests pass 
2. Check that if you `pip` install FitBenchmarking without any external packages (`pip` installable or otherwise) you can run FitBenchmarking.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
