### PR TITLE
Issue 693: Add sudo to dockerfile

### DIFF
--- a/Docker/BasicInstall/Dockerfile
+++ b/Docker/BasicInstall/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     python3-dev \
     python3-venv \
-    git
+    git \
+    sudo
 
 # set up a venv to stop python/python3 sillyness
 ENV VIRTUAL_ENV=/opt/venv


### PR DESCRIPTION
Azure pipelines adds a new user with sudo permissions to run tests in a container.
This means that the user has no root access on standard machines as these do not include sudo (?!).

Add sudo here so that pipelines can install python packages to the venv that we create with the root (default) account.

#### Description of Work

Install sudo in dockerfile

Fixes #693

#### Testing Instructions

1. Build a docker container from the dockerfile:
   `docker build --tag test Docker/BasicInstall`
2. Log in to the container
   `docker run -it test /bin/bash`
3. Verify sudo is installed
   `which sudo`

--- OR ---

3. Add a new user
   `useradd -m -u 1001 vsts_azpcontainer`
4. Give new user sudo priveledges
   `groupadd azure_pipelines_sudo`
   `usermod -a -G azure_pipelines_sudo vsts_azpcontainer`
   `su -c "echo '%azure_pipelines_sudo ALL=(ALL:ALL) NOPASSWD:ALL' >> /etc/sudoers"`
5. Switch to the user
   `su - vsts_azpcontainer`
6. Try to run a sudo command
   `sudo pwd`

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
