### PR TITLE
Issue #708: Use min arg rather than best

### DIFF
--- a/fitbenchmarking/results_processing/plots.py
+++ b/fitbenchmarking/results_processing/plots.py
@@ -180,7 +180,7 @@ class Plot(object):
                        plot_options=plot_options_dict,
                        y=y)
         self.format_plot()
-        file = "{}_fit_for_{}.png".format(self.result.sanitised_min_name,
+        file = "{}_fit_for_{}.png".format(minimizer,
                                           self.result.sanitised_name)
         file_name = os.path.join(self.figures_dir, file)
         self.fig.savefig(file_name)
@@ -219,7 +219,7 @@ class Plot(object):
                        x=self.x,
                        y=self.problem.eval_model(params, x=self.x))
         self.format_plot()
-        file = "{}_fit_for_{}.png".format(self.result.sanitised_min_name,
+        file = "{}_fit_for_{}.png".format(minimizer,
                                           self.result.sanitised_name)
         file_name = os.path.join(self.figures_dir, file)
         self.fig.savefig(file_name)


### PR DESCRIPTION
#### Description of Work
Revrts to using the minimizer arg for generating plots rather than the stored argument.


Fixes #708


#### Testing Instructions

1. Run Fitbenchmarking with plots
2. Check that plots display the correct minimizer
3. Check that plots folder contains a full set of files

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
