### PR TITLE
Change action trigger to only run if a release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: 'Build and Publish'
 
 on:
-  push:
-    branches:
-      - 'release-**'
+  release:
+    types: [published]
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
I just found theres a release trigger which seems better than building on every push to release-**
