### PR TITLE
Fix badges in branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - 'master'
       - 'release-**'
+  release:
+    types: [published]
   schedule:
     - cron: '0 9 * * Mon'
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.6'
+    - name: 'Pin version in README.md'
+      run: |
+        short_ref=${GITHUB_REF#refs/tags}
+        sed -i -e "s|fitbenchmarking/Build%20and%20Publish|&/${short_ref}|" \
+               -e "s|actions/workflows/release.yml|&?query=branch%3A${short_ref}|" \
+               -e "s|fitbenchmarking/Tests|&/${short_ref}|" \
+               -e "s|actions/workflows/main.yml|&?query=branch%3A${short_ref}|" \
+               -e "s|/readthedocs/fitbenchmarking|&/${short_ref}|"
+               -e "s|readthedocs.io/en/latest|/en/${short_ref}|" \
+               README.md
     - name: 'Build'
       run: |
         python3 -m pip install --user --upgrade setuptools wheel

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://img.shields.io/github/workflow/status/fitbenchmarking/fitbenchmarking/Tests?style=flat-square)](https://github.com/fitbenchmarking/fitbenchmarking/actions)
+[![Build Status](https://img.shields.io/github/workflow/status/fitbenchmarking/fitbenchmarking/Build%20and%20Publish?style=flat-square)](https://github.com/fitbenchmarking/fitbenchmarking/actions/workflows/release.yml)
+[![Tests Status](https://img.shields.io/github/workflow/status/fitbenchmarking/fitbenchmarking/Tests?label=tests&style=flat-square)](https://github.com/fitbenchmarking/fitbenchmarking/actions/workflows/main.yml)
 [![Documentation Status](https://img.shields.io/readthedocs/fitbenchmarking?style=flat-square)](https://fitbenchmarking.readthedocs.io/en/latest)
 [![Coverage Status](https://img.shields.io/coveralls/github/fitbenchmarking/fitbenchmarking.svg?style=flat-square)](https://coveralls.io/github/fitbenchmarking/fitbenchmarking)
 ![Windows Supported](https://img.shields.io/badge/win10-support-blue.svg?style=flat-square&logo=windows)


### PR DESCRIPTION
Touches up badges before submitting build to pypi, so that versions are fixed.

I'm not sure we'll be able to do the same for the badges that show up on the docs though as RTD pulls the tagged commit so I can't intercept it before it goes.
