### PR TITLE
Upgrade docker version

### DIFF
--- a/Docker/BasicInstall/Dockerfile
+++ b/Docker/BasicInstall/Dockerfile
@@ -1,6 +1,8 @@
 # Use ubuntu as a parent image
 FROM ubuntu:20.04
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install the packages we need to build fitbenchmarking
 RUN apt-get update && apt-get install -y \
     python3 \

--- a/Docker/BasicInstall/Dockerfile
+++ b/Docker/BasicInstall/Dockerfile
@@ -1,5 +1,5 @@
 # Use ubuntu as a parent image
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Install the packages we need to build fitbenchmarking
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
#### Description of Work

Latest minuit requires cmake version 3.13, this is not available from the package manager on Ubuntu 18.04 so switch to 20.04.

Function: Does the change do what it's supposed to?
Tests: Does it pass? Is there adequate coverage for new code?
Style: Is the coding style consistent? Is anything overly confusing?
Documentation: Is there a suitable change to documentation for this change?
