### PR TITLE
Build mantid

### DIFF
--- a/Docker/FullInstall/Dockerfile
+++ b/Docker/FullInstall/Dockerfile
@@ -118,7 +118,6 @@ ENV HDF5_DISABLE_VERSION_CHECK=2
 RUN /opt/Mantid/bin/mantidpython -m  mantid.simpleapi || echo "expected segfault on first run"
 
 WORKDIR /
-#RUN rm -rf mantid-6.0.0-Source
 
 #################
 # install pygsl #

--- a/Docker/FullInstall/Dockerfile
+++ b/Docker/FullInstall/Dockerfile
@@ -79,20 +79,45 @@ RUN python -m pip install pycutest
 # Install Mantid #
 ##################
 
+WORKDIR /
 # set noninteractive to stop tzdata prompt
 ENV DEBIAN_FRONTEND=noniteractive
+ENV VIRTUAL_ENV=""
+ENV OLD_PATH=$PATH
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN apt-get install -y git g++ qt5-default clang-format-6.0 cmake dvipng doxygen libtbb-dev \
+  libgoogle-perftools-dev libboost-all-dev libpoco-dev libnexus-dev libhdf5-dev libhdf4-dev \
+  libjemalloc-dev libgsl-dev liboce-visualization-dev libmuparser-dev libssl-dev libjsoncpp-dev \
+  librdkafka-dev qtbase5-dev qttools5-dev qttools5-dev-tools libqt5webkit5-dev \
+  libqt5x11extras5-dev libqt5opengl5-dev libqscintilla2-qt5-dev libpython3-dev \
+  ninja-build python3-setuptools python3-sip-dev python3-pyqt5 pyqt5-dev pyqt5-dev-tools \
+  python3-qtpy python3-numpy python3-scipy python3-sphinx python3-sphinx-bootstrap-theme \
+  python3-pycifrw python3-dateutil python3-matplotlib python3-qtconsole python3-h5py \
+  python3-mock python3-psutil python3-requests python3-toml python3-yaml wget
 
-RUN apt-get install -y --fix-missing wget \
-                       lsb-release \ 
-		       software-properties-common
-RUN wget -O - http://apt.isis.rl.ac.uk/2E10C193726B7213.asc -q | apt-key add -
-RUN apt-add-repository "deb [arch=amd64] http://apt.isis.rl.ac.uk $(lsb_release -c | cut -f 2) main" -y 
-RUN apt-add-repository ppa:mantid/mantid -y
-RUN apt-get update && apt-get install mantid -y
+# Details from mantid website
+RUN wget https://downloads.sourceforge.net/project/mantid/6.0/mantid-6.0.0-Source.tar.xz
+RUN tar -xvf mantid-6.0.0-Source.tar.xz
+RUN rm mantid*.xz
 
+RUN apt-get install -y ccache
+RUN ccache --max-size=20G
+
+RUN mkdir -p /opt/Mantid
+
+WORKDIR /opt/Mantid
+RUN cmake /mantid-6.0.0-Source -DENABLE_MANTIDPLOT=OFF
+RUN make
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH=$OLD_PATH
+RUN unset OLD_PATH
 ENV PYTHONPATH=$PYTHONPATH:/opt/Mantid/lib:/opt/Mantid/bin
-RUN pip install IPython six
+RUN python -m pip install IPython six
 RUN /opt/Mantid/bin/mantidpython -m  mantid.simpleapi || echo "expected segfault on first run"
+
+WORKDIR /
+RUN rm -rf mantid-6.0.0-Source
 
 #################
 # install pygsl #

--- a/Docker/FullInstall/Dockerfile
+++ b/Docker/FullInstall/Dockerfile
@@ -113,11 +113,12 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=$OLD_PATH
 RUN unset OLD_PATH
 ENV PYTHONPATH=$PYTHONPATH:/opt/Mantid/lib:/opt/Mantid/bin
-RUN python -m pip install IPython six
+RUN python -m pip install IPython six python-dateutil pyyaml h5py
+ENV HDF5_DISABLE_VERSION_CHECK=2
 RUN /opt/Mantid/bin/mantidpython -m  mantid.simpleapi || echo "expected segfault on first run"
 
 WORKDIR /
-RUN rm -rf mantid-6.0.0-Source
+#RUN rm -rf mantid-6.0.0-Source
 
 #################
 # install pygsl #


### PR DESCRIPTION
Update docker container to build mantid.
Builds it into /opt/Mantid (standard location).

Note, can't clean the source files away as they're used for the python API