### PR TITLE
Add support for bounds for minuit, ralfit and dfo

### DIFF
--- a/docs/source/users/problem_definition_files/native.rst
+++ b/docs/source/users/problem_definition_files/native.rst
@@ -95,5 +95,5 @@ parameter_ranges
   Similarly to `fit_ranges`, it takes the form where the first number
   is the minimum in the range and the second is the maximum.
 
-  Currently in Fitbenchmarking, problems with `parameter_ranges` can only
-  be handled by SciPy fitting software.
+  Currently in Fitbenchmarking, problems with `parameter_ranges` can
+  be handled by SciPy, Minuit, DFO, and RALFit fitting software.

--- a/fitbenchmarking/controllers/dfo_controller.py
+++ b/fitbenchmarking/controllers/dfo_controller.py
@@ -56,23 +56,22 @@ class DFOController(Controller):
         for name in self._param_names:
             if self.problem.value_ranges is not None \
                     and name in self.problem.value_ranges:
-                value_ranges_lb = np.append(value_ranges_lb, \
-                    self.problem.value_ranges[name][0])
-                value_ranges_ub = np.append(value_ranges_ub, \
-                    self.problem.value_ranges[name][1])
-                bound_range = np.append(bound_range, \
-                    self.problem.value_ranges[name][1] \
-                    - self.problem.value_ranges[name][0])
+                value_ranges_lb = np.append(value_ranges_lb,
+                                            self.problem.value_ranges[name][0])
+                value_ranges_ub = np.append(value_ranges_ub,
+                                            self.problem.value_ranges[name][1])
+                bound_range = np.append(bound_range,
+                                        self.problem.value_ranges[name][1]
+                                        - self.problem.value_ranges[name][0])
             else:
                 value_ranges_lb = np.append(value_ranges_lb, -10e+20)
                 value_ranges_ub = np.append(value_ranges_ub, 10e+20)
         self.value_ranges = (value_ranges_lb, value_ranges_ub)
 
-
         # if bounds are set then gap between lower and upper bound must
         # be at least 2*rhobeg so check that default rhobeg value
         # satisfies this condition
-        self.rhobeg = 0.1*max(np.linalg.norm(self._pinit, np.inf),1)
+        self.rhobeg = 0.1*max(np.linalg.norm(self._pinit, np.inf), 1)
         if bound_range.size:
             if min(bound_range) <= 2*self.rhobeg:
                 self.rhobeg = min(bound_range/2)
@@ -84,13 +83,13 @@ class DFOController(Controller):
         if self.minimizer == 'dfogn':
             self._soln = dfogn.solve(self.cost_func.eval_r,
                                      self._pinit,
-                                     rhobeg = self.rhobeg,
+                                     rhobeg=self.rhobeg,
                                      lower=self.value_ranges[0],
                                      upper=self.value_ranges[1])
         elif self.minimizer == 'dfols':
             self._soln = dfols.solve(self.cost_func.eval_r,
                                      self._pinit,
-                                     rhobeg = self.rhobeg,
+                                     rhobeg=self.rhobeg,
                                      bounds=(self.value_ranges))
 
         self._popt = self._soln.x

--- a/fitbenchmarking/controllers/dfo_controller.py
+++ b/fitbenchmarking/controllers/dfo_controller.py
@@ -25,6 +25,8 @@ class DFOController(Controller):
         """
         super(DFOController, self).__init__(cost_func)
 
+        self.support_for_bounds = True
+        self._param_names = self.problem.param_names
         self._soln = None
         self._popt = None
         self._pinit = None
@@ -48,16 +50,48 @@ class DFOController(Controller):
         """
         self._pinit = np.asarray(self.initial_params)
 
+        value_ranges_lb = np.array([])
+        value_ranges_ub = np.array([])
+        bound_range = np.array([])
+        for name in self._param_names:
+            if self.problem.value_ranges is not None \
+                    and name in self.problem.value_ranges:
+                value_ranges_lb = np.append(value_ranges_lb, \
+                    self.problem.value_ranges[name][0])
+                value_ranges_ub = np.append(value_ranges_ub, \
+                    self.problem.value_ranges[name][1])
+                bound_range = np.append(bound_range, \
+                    self.problem.value_ranges[name][1] \
+                    - self.problem.value_ranges[name][0])
+            else:
+                value_ranges_lb = np.append(value_ranges_lb, -10e+20)
+                value_ranges_ub = np.append(value_ranges_ub, 10e+20)
+        self.value_ranges = (value_ranges_lb, value_ranges_ub)
+
+
+        # if bounds are set then gap between lower and upper bound must
+        # be at least 2*rhobeg so check that default rhobeg value
+        # satisfies this condition
+        self.rhobeg = 0.1*max(np.linalg.norm(self._pinit, np.inf),1)
+        if bound_range.size:
+            if min(bound_range) <= 2*self.rhobeg:
+                self.rhobeg = min(bound_range/2)
+
     def fit(self):
         """
         Run problem with DFO.
         """
         if self.minimizer == 'dfogn':
             self._soln = dfogn.solve(self.cost_func.eval_r,
-                                     self._pinit)
+                                     self._pinit,
+                                     rhobeg = self.rhobeg,
+                                     lower=self.value_ranges[0],
+                                     upper=self.value_ranges[1])
         elif self.minimizer == 'dfols':
             self._soln = dfols.solve(self.cost_func.eval_r,
-                                     self._pinit)
+                                     self._pinit,
+                                     rhobeg = self.rhobeg,
+                                     bounds=(self.value_ranges))
 
         self._popt = self._soln.x
         self._status = self._soln.flag

--- a/fitbenchmarking/controllers/minuit_controller.py
+++ b/fitbenchmarking/controllers/minuit_controller.py
@@ -33,7 +33,7 @@ class MinuitController(Controller):
                                        '2.0.0'.format(iminuit_version))
 
         super(MinuitController, self).__init__(cost_func)
-        
+
         self.support_for_bounds = True
         self._param_names = self.problem.param_names
         self._popt = None
@@ -80,7 +80,7 @@ class MinuitController(Controller):
                      self.problem.value_ranges[name][1]))
             else:
                 self.value_ranges.append((None, None))
-        
+
         self._minuit_problem.limits = self.value_ranges
 
     def fit(self):

--- a/fitbenchmarking/controllers/minuit_controller.py
+++ b/fitbenchmarking/controllers/minuit_controller.py
@@ -33,6 +33,9 @@ class MinuitController(Controller):
                                        '2.0.0'.format(iminuit_version))
 
         super(MinuitController, self).__init__(cost_func)
+        
+        self.support_for_bounds = True
+        self._param_names = self.problem.param_names
         self._popt = None
         self._initial_step = None
         self._minuit_problem = None
@@ -67,6 +70,18 @@ class MinuitController(Controller):
                                       self.initial_params)
         self._minuit_problem.errordef = 1
         self._minuit_problem.errors = self._initial_step
+
+        self.value_ranges = []
+        for name in self._param_names:
+            if self.problem.value_ranges is not None \
+                    and name in self.problem.value_ranges:
+                self.value_ranges.append(
+                    (self.problem.value_ranges[name][0],
+                     self.problem.value_ranges[name][1]))
+            else:
+                self.value_ranges.append((None, None))
+        
+        self._minuit_problem.limits = self.value_ranges
 
     def fit(self):
         """

--- a/fitbenchmarking/controllers/ralfit_controller.py
+++ b/fitbenchmarking/controllers/ralfit_controller.py
@@ -87,8 +87,8 @@ class RALFitController(Controller):
                                     self.cost_func.eval_r,
                                     self.jacobian.eval,
                                     options=self._options,
-                                    lower_bounds = self.value_ranges[0],
-                                    upper_bounds = self.value_ranges[1])[0]
+                                    lower_bounds=self.value_ranges[0],
+                                    upper_bounds=self.value_ranges[1])[0]
         self._status = 0 if self._popt is not None else 1
 
     def cleanup(self):

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -127,6 +127,7 @@ class ControllerSharedTesting:
         controller.cleanup()
         assert controller.flag == 2
 
+
 class BaseControllerTests(TestCase):
     """
     Tests for base software controller class methods.
@@ -390,6 +391,7 @@ class DefaultControllerTests(TestCase):
         controller._status = -1
         self.shared_tests.check_diverged(controller)
 
+
 class DefaultControllerBoundsTests(TestCase):
 
     def setUp(self):
@@ -450,10 +452,12 @@ class DefaultControllerBoundsTests(TestCase):
         controller.fit()
         controller.cleanup()
 
-        lower = [controller.value_ranges[i][0] for i in range(len(controller.value_ranges))]
-        upper = [controller.value_ranges[i][1] for i in range(len(controller.value_ranges))]
+        lower = [controller.value_ranges[i][0]
+                 for i in range(len(controller.value_ranges))]
+        upper = [controller.value_ranges[i][1]
+                 for i in range(len(controller.value_ranges))]
 
-        # Convert None values to -inf/inf 
+        # Convert None values to -inf/inf
         lower = [-np.inf if x is None else x for x in lower]
         upper = [np.inf if x is None else x for x in upper]
 
@@ -476,6 +480,7 @@ class DefaultControllerBoundsTests(TestCase):
         for count, value in enumerate(controller.final_params):
             assert controller.value_ranges[0][count] <= value \
                 <= controller.value_ranges[1][count]
+
 
 @pytest.mark.skipif("TEST_TYPE == 'default'")
 class ExternalControllerTests(TestCase):
@@ -647,6 +652,7 @@ class ExternalControllerTests(TestCase):
             controller._status = 2
             self.shared_tests.check_diverged(controller)
 
+
 @pytest.mark.skipif("TEST_TYPE == 'default'")
 class ExternalControllerBoundsTests(TestCase):
 
@@ -676,6 +682,7 @@ class ExternalControllerBoundsTests(TestCase):
         for count, value in enumerate(controller.final_params):
             assert controller.value_ranges[0][count] <= value \
                 <= controller.value_ranges[1][count]
+
 
 class FactoryTests(TestCase):
     """

--- a/fitbenchmarking/systests/linux_expected_results/all_parsers.txt
+++ b/fitbenchmarking/systests/linux_expected_results/all_parsers.txt
@@ -1,8 +1,8 @@
                                 bumps                   gsl               levmar                    mantid                 ralfit                     scipy              scipy_ls
-                               amoeba                lmsder               levmar                      BFGS                     gn               Nelder-Mead       lm-scipy-no-jac
+                               amoeba                lmsder               levmar                      BFGS      gn: scipy 2-point               Nelder-Mead       lm-scipy-no-jac
 BENNETT5            1.608e-05 (1.001)  1.639e-05 (1.021)[1]       0.02183 (1359)         0.02056 (1281)[2]          1.606e-05 (1)      1.653e-05 (1.029)[1]  1.904e-05 (1.186)[1]
 cubic, Start 1  1.119e-14 (2.899e+07)         3.861e-22 (1)    148.9 (3.857e+23)      370.8 (9.604e+23)[2]  6.723e-13 (1.741e+09)  6.267e-05 (1.623e+17)[1]         3.861e-22 (1)
 cubic, Start 2  1.146e-14 (2.969e+07)         3.861e-22 (1)  0.01778 (4.604e+19)  0.0005949 (1.541e+18)[2]  6.926e-18 (1.794e+04)     7.176e-11 (1.859e+11)         3.861e-22 (1)
 cubic-fba       1.146e-14 (2.969e+07)         3.861e-22 (1)  0.01778 (4.604e+19)     3.306e-06 (8.563e+15)   9.768e-18 (2.53e+04)     7.176e-11 (1.859e+11)         3.861e-22 (1)
 EMU 73673           1.032e+05 (98.62)       1053 (1.006)[1]    2.444e+04 (23.36)           1553 (1.484)[2]               1046 (1)              1055 (1.009)              1046 (1)
-Problem Def 1           6.784e+05 (1)          inf (inf)[4]         inf (inf)[4]              inf (inf)[4]           inf (inf)[4]              inf (inf)[4]          inf (inf)[4]
+Problem Def 1   6.784e+05 (6.062e+06)          inf (inf)[4]         inf (inf)[4]              inf (inf)[4]             0.1119 (1)              inf (inf)[4]          inf (inf)[4]


### PR DESCRIPTION
#### Description of Work

Fixes [#740](https://github.com/fitbenchmarking/fitbenchmarking/issues/740)

Add upper and lower bounds to each controller and add tests to check bounds are respected. 

In the dfo controller, the argument `rhobeg` is also checked. This is because when specifying bounds, the gap between a lower and upper bound must be at least `2*rhobeg` -if this condition is not satisfied then the value of `rhobeg` is changed to the maximum possible value given the bounds for the problem.

#### Testing Instructions

1. Run Fitbenchmarking with minuit, ralfit and dfo fitting software
2. For problems with no parameter bounds, check that results are consistent
3. For SASView problems, check that bounds are respected

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
