### PR TITLE
bounds support for mantid problems

### DIFF
--- a/docs/source/users/problem_definition_files/native.rst
+++ b/docs/source/users/problem_definition_files/native.rst
@@ -89,8 +89,7 @@ fit_ranges
 
 parameter_ranges
   An optional setting which specifies upper and lower bounds for 
-  parameters in the problem. This setting cannot currently be used
-  with Mantid problems.
+  parameters in the problem.
 
   Similarly to `fit_ranges`, it takes the form where the first number
   is the minimum in the range and the second is the maximum.

--- a/fitbenchmarking/controllers/base_controller.py
+++ b/fitbenchmarking/controllers/base_controller.py
@@ -96,6 +96,10 @@ class Controller:
         # in the fitting software have support for bounds
         self.support_for_bounds = False
 
+        # Format parameter names so they are lower case and can be compared
+        # to lower case parameter_range names
+        self._param_names = [x.lower() for x in self.problem.param_names]
+
     @property
     def flag(self):
         """

--- a/fitbenchmarking/controllers/bumps_controller.py
+++ b/fitbenchmarking/controllers/bumps_controller.py
@@ -30,7 +30,6 @@ class BumpsController(Controller):
         """
         super(BumpsController, self).__init__(cost_func)
 
-        self._param_names = self.problem.param_names
         self.support_for_bounds = True
         self._func_wrapper = None
         self._fit_problem = None

--- a/fitbenchmarking/controllers/dfo_controller.py
+++ b/fitbenchmarking/controllers/dfo_controller.py
@@ -26,7 +26,6 @@ class DFOController(Controller):
         super(DFOController, self).__init__(cost_func)
 
         self.support_for_bounds = True
-        self._param_names = self.problem.param_names
         self._soln = None
         self._popt = None
         self._pinit = None

--- a/fitbenchmarking/controllers/minuit_controller.py
+++ b/fitbenchmarking/controllers/minuit_controller.py
@@ -35,7 +35,6 @@ class MinuitController(Controller):
         super(MinuitController, self).__init__(cost_func)
 
         self.support_for_bounds = True
-        self._param_names = self.problem.param_names
         self._popt = None
         self._initial_step = None
         self._minuit_problem = None

--- a/fitbenchmarking/controllers/ralfit_controller.py
+++ b/fitbenchmarking/controllers/ralfit_controller.py
@@ -26,7 +26,6 @@ class RALFitController(Controller):
         super(RALFitController, self).__init__(cost_func)
 
         self.support_for_bounds = True
-        self._param_names = self.problem.param_names
         self._popt = None
         self._options = {}
         self.algorithm_check = {

--- a/fitbenchmarking/controllers/scipy_controller.py
+++ b/fitbenchmarking/controllers/scipy_controller.py
@@ -26,7 +26,6 @@ class ScipyController(Controller):
         """
         super(ScipyController, self).__init__(cost_func)
 
-        self._param_names = self.problem.param_names
         self.support_for_bounds = True
         self.no_bounds_minimizers = ['Nelder-Mead', 'CG', 'BFGS', 'Newton-CG']
         self._popt = None

--- a/fitbenchmarking/controllers/scipy_ls_controller.py
+++ b/fitbenchmarking/controllers/scipy_ls_controller.py
@@ -23,7 +23,6 @@ class ScipyLSController(Controller):
                 :class:`~fitbenchmarking.cost_func.base_cost_func.CostFunc`
         """
         super(ScipyLSController, self).__init__(cost_func)
-        self._param_names = self.problem.param_names
         self.support_for_bounds = True
         self.no_bounds_minimizers = ['lm-scipy-no-jac', 'lm-scipy']
         self._popt = None


### PR DESCRIPTION
#### Description of Work

Fixes [#741](https://github.com/fitbenchmarking/fitbenchmarking/issues/741)

Changes `self._param_names` within controllers to all lower case as `parameter_ranges` names are also set to be lower case. This means that `parameter_ranges` can be handled correctly for problems with upper case parameter names e.g. `'A1'`


#### Testing Instructions

1. Run Fitbenchmarking with a Mantid problem that has `parameter_ranges` set
2. Check in results that bounds are being respected

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
