### PR TITLE
Updated documentation .rst files and the minuit_controller.py docstring to address written expression errors

### DIFF
--- a/docs/source/contributors/workflow.rst
+++ b/docs/source/contributors/workflow.rst
@@ -32,17 +32,17 @@ Please ensure our :ref:`guidelines` are adhered to throughout
 the branch.
 
 When you think your new code is ready to be merged into the codebase,
-you should open a pull request to master.
+you should open a pull request (PR) to master.
 The description should contain the
 words `Fixes #<nnn>`, where `<nnn>` is the issue number; this will ensure
 the issue is closed when the code is merged into master.  At this point
 the automated tests will trigger, and you can see if the code passes on
 an independent system.
 
-Sometimes it is desirable to open a pull request when the code is not
+Sometimes it is desirable to open a PR when the code is not
 quite ready to be merged.  This is a good idea, for example, if you want
 to get an early opinion on a coding descision.  If this is the case, you
-should mark the pull request as a *draft* on GitHub.
+should mark the PR as a *draft* on GitHub.
 
 Once the work is ready to be reviewed, you may want to assign a reviewer,
 if you think someone would be well suited to review this change.  It is worth
@@ -55,7 +55,7 @@ Release branches
 
 Branches named `release-*` are protected branches; code must be approved by
 a reviewer before being added to them, and automated tests will be run on
-pull requests to these branches.  If code is to be included in the release, it
+PRs to these branches.  If code is to be included in the release, it
 must be pulled into this branch from master.
 
 Release branches should have the format `release-major.minor.x`, starting from
@@ -65,7 +65,7 @@ be created accordingly.  If at some point we don't want to provide hot-fixes
 to a given minor release, then the corresponding release branch may be deleted.
 
 All changes must be initially merged into master.
-There is a `backport-candidate` label, which must be put on pull requests
+There is a `backport-candidate` label, which must be put on PRs
 that in addition must be merged into the release branch.
 
 The recommended mechanism for merging PRs lablelled with `backport-candidate` into

--- a/docs/source/users/install_instructions/fitbenchmarking.rst
+++ b/docs/source/users/install_instructions/fitbenchmarking.rst
@@ -80,7 +80,7 @@ where valid strings ``option-x`` are:
 * ``levmar`` -- installs the `levmar <http://users.ics.forth.gr/~lourakis/levmar/>`_ fitting package.  Note that the interface we use also requires BLAS and LAPLACK to be installed on the system, and calls to this minimizer will fail if these libraries are not present.
 * ``minuit`` -- installs the `Minuit <http://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/>`_ fitting package.
 * ``SAS`` -- installs the `Sasmodels <https://github.com/SasView/sasmodels>`_ fitting package.
-  * ``numdifftools`` -- installs the `numdifftools <https://numdifftools.readthedocs.io/en/latest/index.html>`_ numerical differentiation package.
+* ``numdifftools`` -- installs the `numdifftools <https://numdifftools.readthedocs.io/en/latest/index.html>`_ numerical differentiation package.
 
 
 .. |Python 3.6+| image:: https://img.shields.io/badge/python-3.6+-blue.svg

--- a/docs/source/users/options/plotting_option.rst
+++ b/docs/source/users/options/plotting_option.rst
@@ -16,7 +16,7 @@ Default is ``True`` (``yes``/``no`` can also be used)
 
 .. code-block:: rst
 
-    [FITTING]
+    [PLOTTING]
     make_plots: yes
 
 Colour scale (:code:`colour_scale`)
@@ -31,7 +31,7 @@ Default thresholds are ``1.1, 1.33, 1.75, 3, and inf``
 
 .. code-block:: rst
 
-    [FITTING]
+    [PLOTTING]
     colour_scale: 1.1, #fef0d9
                   1.33, #fdcc8a
                   1.75, #fc8d59
@@ -55,7 +55,7 @@ Default is ``both``
 
 .. code-block:: rst
 
-    [FITTING]
+    [PLOTTING]
     comparison_mode: both
 
 
@@ -77,7 +77,7 @@ Default is ``acc``, ``runtime``, ``compare``, and ``local_min``.
 
 .. code-block:: rst
 
-    [FITTING]
+    [PLOTTING]
     table_type: acc
                 runtime
                 compare
@@ -93,5 +93,5 @@ Default is ``results``
 
 .. code-block:: rst
 
-    [FITTING]
+    [PLOTTING]
     results_dir: results

--- a/docs/source/users/running.rst
+++ b/docs/source/users/running.rst
@@ -18,7 +18,7 @@ Running alternative problems
 Other problems written in a :ref:`supported file format <problem_def>`
 can be analyzed with FitBenchmarking by
 passing the path using the ``--problem-sets`` (or ``-p``) option.
-A example problems can be downloaded from
+Example problems can be downloaded from
 :ref:`BenchmarkProblems`, and they can also be found in the
 ``fitbenchmarking/examples`` directory of the code.
 

--- a/fitbenchmarking/controllers/minuit_controller.py
+++ b/fitbenchmarking/controllers/minuit_controller.py
@@ -1,5 +1,5 @@
 """
-Implements a controller for the CERN pacakage Minuit
+Implements a controller for the CERN package Minuit
 https://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/
 using the iminuit python interface
 http://iminuit.readthedocs.org


### PR DESCRIPTION
#### Description of Work

**Users -> Installation -> Installing FitBenchmarking and default fitting packages:** users/install_instructions/fitbenchmarking.rst edited so that last bullet point list on page now formatted in line with other bullet points.

**Contributors -> Module Index -> fitbenchmarking.controllers.minuit_controllermodule:** minuit_controller.py docstring updated to correct  "pacakage" to "package".

**Users -> Running FitBenchmarking:** users/running.rst "A example problems can be downloaded" corrected to "Example problems can be downloaded"...

**Contributors -> Git Workflow:**  contributors/workflow.rst edited so that on the first mention of "pull request" the acronym PR is introduced like so "pull request (PR)" and any subsequent references to pull requests now use the acronym.

**Users -> FitBenchmarking Options -> Plotting Options** users/option/plotting_option.rst edited so that the correct option section "[PLOTTING]" is now seen in the instructional commands rather than "[FITTING]" which is incorrect.


#### Testing Instructions

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
