### PR TITLE
flake8 and pylint E and W fixes for cli

### DIFF
--- a/fitbenchmarking/cli/exception_handler.py
+++ b/fitbenchmarking/cli/exception_handler.py
@@ -13,6 +13,7 @@ LOGGER = get_logger()
 
 
 def exception_handler(f):
+    # pylint: disable=W0703
     """
     Decorator to simplify handling exceptions within FitBenchmarking
     This will strip off any 'debug' inputs.

--- a/fitbenchmarking/cli/main.py
+++ b/fitbenchmarking/cli/main.py
@@ -73,7 +73,7 @@ def get_parser():
 
 @exception_handler
 def run(problem_sets, options_file='', debug=False):
-    #pylint: disable=unused-argument
+    # pylint: disable=unused-argument
     """
     Run benchmarking for the problems sets and options file given.
     Opens a webbrowser to the results_index after fitting.

--- a/fitbenchmarking/cli/main.py
+++ b/fitbenchmarking/cli/main.py
@@ -193,7 +193,7 @@ def run(problem_sets, options_file='', debug=False):
 
     if os.path.basename(options.results_dir) == \
             options.DEFAULT_PLOTTING['results_dir']:
-        LOGGER.info("\nWARNING: \nThe FitBenchmarking results will be "
+        LOGGER.info("\nINFO: \nThe FitBenchmarking results will be "
                     "placed into the folder: \n\n   %s\n\nTo change this "
                     "alter the input options "
                     "file.\n", options.results_dir)

--- a/fitbenchmarking/cli/main.py
+++ b/fitbenchmarking/cli/main.py
@@ -142,7 +142,7 @@ def run(problem_sets, options_file='', debug=False):
                       data_dir=data_dir)
 
         # If a result has error flag 4 then the result contains dummy values,
-        # if this is the case for all results then output should not be 
+        # if this is the case for all results then output should not be
         # produced as results tables won't show meaningful values.
         all_dummy_results_flag = True
         for result in results:
@@ -153,7 +153,7 @@ def run(problem_sets, options_file='', debug=False):
         # If the results are an empty list then this means that all minimizers
         # raise an exception and the tables will produce errors if they run
         # for that problem set.
-        if results == [] or all_dummy_results_flag is True :
+        if results == [] or all_dummy_results_flag is True:
             message = "\nWARNING: \nThe user chosen options and/or problem " \
                       " setup resulted in all minimizers and/or parsers " \
                       "raising an exception. Because of this, results for " \

--- a/fitbenchmarking/cli/main.py
+++ b/fitbenchmarking/cli/main.py
@@ -73,6 +73,7 @@ def get_parser():
 
 @exception_handler
 def run(problem_sets, options_file='', debug=False):
+    #pylint: disable=unused-argument
     """
     Run benchmarking for the problems sets and options file given.
     Opens a webbrowser to the results_index after fitting.
@@ -193,9 +194,9 @@ def run(problem_sets, options_file='', debug=False):
     if os.path.basename(options.results_dir) == \
             options.DEFAULT_PLOTTING['results_dir']:
         LOGGER.info("\nWARNING: \nThe FitBenchmarking results will be "
-                    "placed into the folder: \n\n   {}\n\nTo change this "
+                    "placed into the folder: \n\n   %s\n\nTo change this "
                     "alter the input options "
-                    "file.\n".format(options.results_dir))
+                    "file.\n", options.results_dir)
 
     root = os.path.dirname(inspect.getfile(fitbenchmarking))
     template_dir = os.path.join(root, 'templates')

--- a/fitbenchmarking/cli/tests/test_main.py
+++ b/fitbenchmarking/cli/tests/test_main.py
@@ -10,6 +10,7 @@ from fitbenchmarking.utils import fitbm_result, exceptions
 from fitbenchmarking.utils.options import Options
 from fitbenchmarking.parsing.parser_factory import parse_problem_file
 
+
 def make_cost_function(file_name='cubic.dat', minimizers=None):
     """
     Helper function that returns a simple fitting problem
@@ -25,6 +26,7 @@ def make_cost_function(file_name='cubic.dat', minimizers=None):
     fitting_problem.correct_data()
     cost_func = NLLSCostFunc(fitting_problem)
     return cost_func
+
 
 class TestMain(TestCase):
     """
@@ -61,8 +63,8 @@ class TestMain(TestCase):
         results = []
         result_args = {'options': self.options,
                        'cost_func': self.cost_func,
-                       'jac':'jac',
-                       'initial_params':[],
+                       'jac': 'jac',
+                       'initial_params': [],
                        'params': [],
                        'error_flag': 4}
         result = fitbm_result.FittingResult(**result_args)
@@ -71,4 +73,5 @@ class TestMain(TestCase):
         failed_problems = []
         unselected_minimzers = {}
         cost_func_description = []
-        return results, failed_problems, unselected_minimzers, cost_func_description
+        return (results, failed_problems, unselected_minimzers,
+                cost_func_description)

--- a/fitbenchmarking/cli/tests/test_main.py
+++ b/fitbenchmarking/cli/tests/test_main.py
@@ -57,12 +57,12 @@ class TestMain(TestCase):
         """
         Mock function to be used instead of benchmark
         """
-        self.options = Options()
-        self.cost_func = make_cost_function()
+        options = Options()
+        cost_func = make_cost_function()
 
         results = []
-        result_args = {'options': self.options,
-                       'cost_func': self.cost_func,
+        result_args = {'options': options,
+                       'cost_func': cost_func,
                        'jac': 'jac',
                        'initial_params': [],
                        'params': [],


### PR DESCRIPTION
#### Description of Work

Fixes #768


#### Testing Instructions

1. ensure not W and E concerns when running `flake8 fitbenchmarking/cli/*` and `pylint fitbenchmarking/cli/*`
2. look to see if changes in code reasonable
3. agree that for message to user about where results are is better as 'INFO' instead of 'WARNING' 

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
