### PR TITLE
Add warning message for incorrect parameter names in parameter_ranges

### DIFF
--- a/fitbenchmarking/parsing/fitting_problem.py
+++ b/fitbenchmarking/parsing/fitting_problem.py
@@ -12,7 +12,8 @@ except ImportError:
     from itertools import zip_longest as izip_longest
 import numpy as np
 
-from fitbenchmarking.utils.exceptions import FittingProblemError
+from fitbenchmarking.utils.exceptions import FittingProblemError, \
+    IncorrectBoundsError
 
 
 # Using property getters and setters means that the setter does not always use
@@ -223,6 +224,13 @@ class FittingProblem:
         :type params: dict
 
         """
+        if not all(name in self.starting_values[0].keys()
+                   for name in value_ranges):
+            raise IncorrectBoundsError('One or more of the parameter names in '
+                                       'the `parameter_ranges` dictionary is '
+                                       'incorrect, please check the problem '
+                                       'definiton file for this problem.')
+
         self.value_ranges = []
         for name in self.starting_values[0].keys():
             param_name = name.lower()

--- a/fitbenchmarking/parsing/fitting_problem.py
+++ b/fitbenchmarking/parsing/fitting_problem.py
@@ -224,20 +224,20 @@ class FittingProblem:
         :type params: dict
 
         """
-        if not all(name in self.starting_values[0].keys()
-                   for name in value_ranges):
+        lower_param_names = [name.lower()
+                             for name in self.starting_values[0].keys()]
+        if not all(name in lower_param_names for name in value_ranges):
             raise IncorrectBoundsError('One or more of the parameter names in '
                                        'the `parameter_ranges` dictionary is '
                                        'incorrect, please check the problem '
                                        'definiton file for this problem.')
 
         self.value_ranges = []
-        for name in self.starting_values[0].keys():
-            param_name = name.lower()
-            if param_name in value_ranges:
+        for name in lower_param_names:
+            if name in value_ranges:
                 self.value_ranges.append(
-                    (value_ranges[param_name][0],
-                        value_ranges[param_name][1]))
+                    (value_ranges[name][0],
+                        value_ranges[name][1]))
             else:
                 self.value_ranges.append((-np.inf, np.inf))
 

--- a/fitbenchmarking/parsing/tests/test_fitting_problem.py
+++ b/fitbenchmarking/parsing/tests/test_fitting_problem.py
@@ -108,6 +108,19 @@ class TestFittingProblem(TestCase):
         fitting_problem.set_value_ranges(value_ranges_prob_def)
         self.assertEqual(fitting_problem.value_ranges, expected_value_ranges)
 
+    def test_set_value_ranges_incorrect_names(self):
+        """
+        Tests that an exception is raised if parameter names
+        in `parameter_ranges` are incorrect
+        """
+        fitting_problem = FittingProblem(self.options)
+        fitting_problem.starting_values = [OrderedDict(
+            [('param1', 0), ('param2', 0), ('param3', 0)])]
+        value_ranges_prob_def = {'incorrect_name': (0, 5), 'param2': (5, 10)}
+        self.assertRaises(exceptions.IncorrectBoundsError,
+                          fitting_problem.set_value_ranges,
+                          value_ranges_prob_def)
+
     def test_correct_data_single_fit(self):
         """
         Tests that correct data gives the expected result

--- a/fitbenchmarking/utils/exceptions.py
+++ b/fitbenchmarking/utils/exceptions.py
@@ -237,3 +237,17 @@ class IncompatibleTableError(FitBenchmarkException):
                               'compatible with the selected ' \
                               'cost function'
         self.error_code = 18
+        
+
+class IncorrectBoundsError(FitBenchmarkException):
+    """
+    Indicates that `parameter_ranges` have been set incorrectly
+    """
+
+    def __init__(self, message=''):
+        super(IncorrectBoundsError, self).__init__(message)
+
+        self._class_message = 'Bounds for this problem are ' \
+                              'unable to be set, so this ' \
+                              'problem will be skipped.'
+        self.error_code = 19


### PR DESCRIPTION
#### Description of Work

Fixes #777 

#### Testing Instructions

1. Run problems with incorrect parameter names in `parameter_ranges` to check warning message appears as expected
2. Check that problems will correct `parameter_ranges` still run as expected

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
