### PR TITLE
Issue #767: Fix linting complaints

### DIFF
--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -6,22 +6,24 @@ for a certain fitting software.
 
 from __future__ import absolute_import, division, print_function
 
-from collections import defaultdict
+import os
 import timeit
 import warnings
-import os
+from collections import defaultdict
 
 import numpy as np
 
 from fitbenchmarking.controllers.controller_factory import ControllerFactory
 from fitbenchmarking.cost_func.cost_func_factory import create_cost_func
-from fitbenchmarking.parsing.parser_factory import parse_problem_file
-from fitbenchmarking.utils.exceptions import UnknownMinimizerError, \
-    UnsupportedMinimizerError, ControllerAttributeError, NoJacobianError, \
-    IncompatibleMinimizerError
 from fitbenchmarking.jacobian.jacobian_factory import create_jacobian
+from fitbenchmarking.parsing.parser_factory import parse_problem_file
 from fitbenchmarking.utils import fitbm_result, misc, output_grabber
-
+from fitbenchmarking.utils.exceptions import (FitBenchmarkException,
+                                              ControllerAttributeError,
+                                              IncompatibleMinimizerError,
+                                              NoJacobianError,
+                                              UnknownMinimizerError,
+                                              UnsupportedMinimizerError)
 from fitbenchmarking.utils.log import get_logger
 
 LOGGER = get_logger()
@@ -97,17 +99,17 @@ def loop_over_benchmark_problems(problem_group, options):
         problem_passed = True
         info_str = " Running data from: {} {}/{}".format(
             os.path.basename(p), i + 1, len(problem_group))
-        LOGGER.info('\n' + '#' * (len(info_str) + 1))
+        LOGGER.info('\n%s', '#' * (len(info_str) + 1))
         LOGGER.info(info_str)
         LOGGER.info('#' * (len(info_str) + 1))
         try:
             with grabbed_output:
                 parsed_problem = parse_problem_file(p, options)
                 parsed_problem.correct_data()
-        except Exception as e:
+        except FitBenchmarkException as e:
             info_str = " Could not run data from: {} {}/{}".format(
                 p, i + 1, len(problem_group))
-            LOGGER.warn(e)
+            LOGGER.warning(e)
             problem_passed = False
 
         if problem_passed:
@@ -149,8 +151,7 @@ def loop_over_starting_values(cost_func, options, grabbed_output):
     num_start_vals = len(problem.starting_values)
     problem_results = []
     for index in range(num_start_vals):
-        LOGGER.info("    Starting value: {0}/{1}".format(index + 1,
-                                                         num_start_vals))
+        LOGGER.info("    Starting value: %i/%i", index + 1, num_start_vals)
         if num_start_vals > 1:
             problem.name = name + ', Start {}'.format(index + 1)
 
@@ -290,15 +291,15 @@ def loop_over_minimizers(controller, minimizers, options, grabbed_output):
                 minimizer_check = False
                 controller.flag = 4
                 dummy_results = [{'options': options,
-                                 'cost_func': controller.cost_func,
-                                 'jac': None,
-                                 'chi_sq': np.inf,
-                                 'runtime': np.inf,
-                                 'minimizer': minimizer,
-                                 'initial_params': controller.initial_params,
-                                 'params': None,
-                                 'error_flag': controller.flag,
-                                 'name': problem.name}]
+                                  'cost_func': controller.cost_func,
+                                  'jac': None,
+                                  'chi_sq': np.inf,
+                                  'runtime': np.inf,
+                                  'minimizer': minimizer,
+                                  'initial_params': controller.initial_params,
+                                  'params': None,
+                                  'error_flag': controller.flag,
+                                  'name': problem.name}]
                 for result in dummy_results:
                     individual_result = fitbm_result.FittingResult(
                         **result)
@@ -368,11 +369,13 @@ def loop_over_jacobians(controller, options, grabbed_output):
         for jac_method in jacobian_list:
             for num_method in options.num_method[jac_method]:
                 if minimizer_check:
-                    LOGGER.info(
-                        "                Jacobian: {} ".format(jac_method)
-                        + (num_method if jac_method != "analytic" else ''))
-                    minimizer_name = "{}: {} ".format(minimizer, jac_method) \
-                        + (num_method if jac_method != "analytic" else '')
+                    num_method_str = ''
+                    if jac_method != "analytic":
+                        num_method_str = ' ' + num_method
+                    LOGGER.info("                Jacobian: %s%s",
+                                jac_method, num_method_str)
+                    minimizer_name = "{}: {}{}".format(
+                        minimizer, jac_method, num_method_str)
                 # Creates Jacobian class
                 jacobian_cls = create_jacobian(jac_method)
                 try:
@@ -389,10 +392,11 @@ def loop_over_jacobians(controller, options, grabbed_output):
                         with grabbed_output:
                             # Calls timeit repeat with repeat = num_runs and
                             # number = 1
-                            runtime_list = \
-                                timeit.Timer(setup=controller.prepare,
-                                             stmt=controller.fit).repeat(
-                                    num_runs, 1)
+                            runtime_list = timeit.Timer(
+                                setup=controller.prepare,
+                                stmt=controller.fit
+                            ).repeat(num_runs, 1)
+
                             runtime = sum(runtime_list) / num_runs
                             controller.cleanup()
                             controller.check_attributes()

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -205,9 +205,9 @@ def loop_over_fitting_software(cost_func, options, start_values_index,
         LOGGER.info("        Software: %s", s.upper())
         try:
             minimizers = options.minimizers[s]
-        except KeyError:
+        except KeyError as e:
             raise UnsupportedMinimizerError(
-                'No minimizer given for software: {}'.format(s))
+                'No minimizer given for software: {}'.format(s)) from e
         with grabbed_output:
             controller_cls = ControllerFactory.create_controller(
                 software=s)

--- a/fitbenchmarking/core/results_output.py
+++ b/fitbenchmarking/core/results_output.py
@@ -1,17 +1,16 @@
 """
 Functions that create the tables, support pages, figures, and indexes.
 """
-
-from __future__ import (absolute_import, division, print_function)
 import inspect
-import docutils
 import os
-from jinja2 import Environment, FileSystemLoader
 from shutil import copy2
 
+import docutils
+from jinja2 import Environment, FileSystemLoader
+
 import fitbenchmarking
-from fitbenchmarking.results_processing import performance_profiler, plots, \
-    support_page, tables
+from fitbenchmarking.results_processing import (performance_profiler, plots,
+                                                support_page, tables)
 from fitbenchmarking.utils import create_dirs
 from fitbenchmarking.utils.misc import get_css, get_js
 
@@ -202,9 +201,10 @@ def create_problem_level_index(options, table_names, group_name,
     docsettings = {
         'math_output': 'MathJax '+js['mathjax']
     }
-    description_page = docutils.core.publish_parts(cost_func_description,
-                                                   writer_name='html',
-                                                   settings_overrides=docsettings)
+    description_page = docutils.core.publish_parts(
+        cost_func_description,
+        writer_name='html',
+        settings_overrides=docsettings)
     cost_func = description_page['body'].replace('<blockquote>\n', '')
 
     root = os.path.dirname(inspect.getfile(fitbenchmarking))

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark.py
@@ -1,20 +1,18 @@
 """
 Tests for fitbenchmarking.core.fitting_benchmarking.benchmark
 """
-from __future__ import (absolute_import, division, print_function)
-import inspect
 import copy
+import inspect
 import os
 import unittest
 from unittest import mock
 
 from fitbenchmarking import mock_problems
-from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
-from fitbenchmarking.utils import fitbm_result
 from fitbenchmarking.core.fitting_benchmarking import benchmark
+from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
 from fitbenchmarking.parsing.parser_factory import parse_problem_file
+from fitbenchmarking.utils import fitbm_result
 from fitbenchmarking.utils.options import Options
-from fitbenchmarking.utils.exceptions import NoResultsError
 
 # Defines the module which we mock out certain function calls for
 FITTING_DIR = "fitbenchmarking.core.fitting_benchmarking"

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark_problems.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark_problems.py
@@ -9,7 +9,8 @@ import unittest
 from fitbenchmarking import mock_problems
 from fitbenchmarking.core.fitting_benchmarking import \
     loop_over_benchmark_problems
-from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
+from fitbenchmarking.cost_func.weighted_nlls_cost_func import \
+    WeightedNLLSCostFunc
 from fitbenchmarking.parsing.parser_factory import parse_problem_file
 from fitbenchmarking.utils import fitbm_result
 from fitbenchmarking.utils.options import Options
@@ -34,7 +35,7 @@ def make_cost_function(file_name='cubic.dat', minimizers=None):
 
     fitting_problem = parse_problem_file(fname, options)
     fitting_problem.correct_data()
-    cost_func = NLLSCostFunc(fitting_problem)
+    cost_func = WeightedNLLSCostFunc(fitting_problem)
     return cost_func
 
 

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark_problems.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_benchmark_problems.py
@@ -2,17 +2,16 @@
 Tests for
 fitbenchmarking.core.fitting_benchmarking.loop_over_benchmark_problems
 """
-from __future__ import (absolute_import, division, print_function)
 import inspect
 import os
 import unittest
 
 from fitbenchmarking import mock_problems
-from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
-from fitbenchmarking.utils import fitbm_result, exceptions
 from fitbenchmarking.core.fitting_benchmarking import \
     loop_over_benchmark_problems
+from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
 from fitbenchmarking.parsing.parser_factory import parse_problem_file
+from fitbenchmarking.utils import fitbm_result
 from fitbenchmarking.utils.options import Options
 
 # Defines the module which we mock out certain function calls for
@@ -96,7 +95,7 @@ class LoopOverBenchmarkProblemsTests(unittest.TestCase):
             unselected_minimzers, expect_minimizers
 
     def shared_tests(self, list_len, expected_problem_fails,
-                     expected_cost_func_descriptions):
+                     expected_cost_func_description):
         """
         Shared tests for the `loop_over_starting_values` function
 
@@ -108,10 +107,12 @@ class LoopOverBenchmarkProblemsTests(unittest.TestCase):
         :type expected_cost_func_descriptions: str
         """
         results, failed_problems, unselected_minimzers, minimizer_dict, \
-            cost_func_descriptions = loop_over_benchmark_problems(
+            cost_func_description = loop_over_benchmark_problems(
                 self.problem_group, self.options)
         assert len(results) == list_len
         assert failed_problems == expected_problem_fails
+        self.assertEqual(expected_cost_func_description,
+                         cost_func_description)
         dict_test(unselected_minimzers, {"scipy": []})
         dict_test(minimizer_dict, {"scipy": ['TNC', 'lm-scipy']})
 
@@ -149,6 +150,7 @@ class LoopOverBenchmarkProblemsTests(unittest.TestCase):
         expected_cost_func_descriptions = self.cost_func.__doc__
         self.shared_tests(expected_list_length, expected_problem_fails,
                           expected_cost_func_descriptions)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_jacobians.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_jacobians.py
@@ -1,19 +1,17 @@
 """
 Tests for fitbenchmarking.core.fitting_benchmarking.loop_over_jacobians
 """
-from __future__ import (absolute_import, division, print_function)
 import inspect
 import os
 import unittest
 
 from fitbenchmarking import mock_problems
-from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
-from fitbenchmarking.utils import fitbm_result, output_grabber
-from fitbenchmarking.core.fitting_benchmarking import loop_over_jacobians
-from fitbenchmarking.parsing.parser_factory import parse_problem_file
 from fitbenchmarking.controllers.base_controller import Controller
+from fitbenchmarking.core.fitting_benchmarking import loop_over_jacobians
+from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
+from fitbenchmarking.parsing.parser_factory import parse_problem_file
+from fitbenchmarking.utils import output_grabber
 from fitbenchmarking.utils.options import Options
-from fitbenchmarking.jacobian.scipy_jacobian import Scipy
 
 
 # Due to construction of the controllers two folder functions
@@ -35,6 +33,8 @@ class DummyController(Controller):
                                 'ls': [None],
                                 'deriv_free': ['deriv_free_algorithm'],
                                 'general': ['general']}
+        self.final_params_expected = [[1, 2, 3, 4], [4, 3, 2, 1]]
+        self.flag_expected = [0, 1]
         self.count = 0
         self.has_jacobian = []
         self.invalid_jacobians = []
@@ -66,6 +66,7 @@ class DummyController(Controller):
         self.final_params = self.final_params_expected[self.count]
         self.flag = self.flag_expected[self.count]
         self.count += 1
+        self.count = self.count % len(self.flag_expected)
 
 
 def make_cost_function(file_name='cubic.dat', minimizers=None):
@@ -112,7 +113,7 @@ class LoopOverJacobiansTests(unittest.TestCase):
         self.controller.invalid_jacobians = ["deriv_free_algorithm"]
         self.controller.minimizer = "general"
         new_name = ['general: scipy 3-point']
-        results, chi_sq, new_minimizer_list = \
+        results, _, new_minimizer_list = \
             loop_over_jacobians(self.controller,
                                 self.options,
                                 self.grabbed_output)
@@ -131,7 +132,7 @@ class LoopOverJacobiansTests(unittest.TestCase):
         self.controller.invalid_jacobians = ["deriv_free_algorithm"]
         self.controller.minimizer = "general"
         new_name = ['general: scipy 3-point', 'general: scipy 2-point']
-        results, chi_sq, new_minimizer_list = \
+        results, _, new_minimizer_list = \
             loop_over_jacobians(self.controller,
                                 self.options,
                                 self.grabbed_output)
@@ -151,7 +152,7 @@ class LoopOverJacobiansTests(unittest.TestCase):
         self.controller.invalid_jacobians = ["deriv_free_algorithm"]
         self.controller.minimizer = "deriv_free_algorithm"
         new_name = ['deriv_free_algorithm']
-        results, chi_sq, new_minimizer_list = \
+        results, _, new_minimizer_list = \
             loop_over_jacobians(self.controller,
                                 self.options,
                                 self.grabbed_output)

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_minimizers.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_minimizers.py
@@ -1,17 +1,16 @@
 """
 Tests for fitbenchmarking.core.fitting_benchmarking.loop_over_minimizers
 """
-from __future__ import (absolute_import, division, print_function)
 import inspect
 import os
 import unittest
 
 from fitbenchmarking import mock_problems
-from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
-from fitbenchmarking.utils import fitbm_result, output_grabber
-from fitbenchmarking.core.fitting_benchmarking import loop_over_minimizers
-from fitbenchmarking.parsing.parser_factory import parse_problem_file
 from fitbenchmarking.controllers.base_controller import Controller
+from fitbenchmarking.core.fitting_benchmarking import loop_over_minimizers
+from fitbenchmarking.cost_func.nlls_cost_func import NLLSCostFunc
+from fitbenchmarking.parsing.parser_factory import parse_problem_file
+from fitbenchmarking.utils import fitbm_result, output_grabber
 from fitbenchmarking.utils.options import Options
 
 # Defines the module which we mock out certain function calls for
@@ -86,6 +85,7 @@ def make_cost_function(file_name='cubic.dat', minimizers=None):
     return cost_func
 
 
+# pylint: disable=attribute-defined-outside-init
 class LoopOverMinimizersTests(unittest.TestCase):
     """
     loop_over_minimizers tests
@@ -174,7 +174,7 @@ class LoopOverMinimizersTests(unittest.TestCase):
         selected with a bounded problem, results have the
         correct error flag
         """
-        self.controller.problem.value_ranges = {'test':(0,1)}
+        self.controller.problem.value_ranges = {'test': (0, 1)}
         self.minimizers = ["general"]
 
         results_problem, minimizer_failed, new_minimizer_list = \
@@ -184,6 +184,7 @@ class LoopOverMinimizersTests(unittest.TestCase):
         assert results_problem[0].error_flag == 4
         assert minimizer_failed == []
         assert new_minimizer_list == ["general"]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_software.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_software.py
@@ -194,10 +194,10 @@ class LoopOverSoftwareTests(unittest.TestCase):
         """
         self.options.software = ['incorrect_software']
         with self.assertRaises(UnsupportedMinimizerError):
-            _, _, _ = loop_over_fitting_software(self.cost_func,
-                                                 self.options,
-                                                 self.start_values_index,
-                                                 self.grabbed_output)
+            _ = loop_over_fitting_software(self.cost_func,
+                                           self.options,
+                                           self.start_values_index,
+                                           self.grabbed_output)
 
 
 if __name__ == "__main__":

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,17 +1,15 @@
-@Article{mantid,
-  Title                    = {Mantid-Data analysis and visualization package for neutron scattering and $\mu$SR experiments},
-  Author                   = {Arnold, O. and Bilheux, J.C. and Borreguero, J.M. and Buts, A. and Campbell, S.I. and Chapon, L. and Doucet, M. and Draper, N. and Ferraz Leal, R. and Gigg, M.A. and et al.},
-  Journal                  = {Nuclear Instruments and Methods in Physics Research Section A},
-  Year                     = {2014},
-
-  Month                    = {November},
-  Note                     = {www.mantidproject.org},
-  Pages                    = {156-166},
-  Volume                   = {764},
-
-  Owner                    = {trees},
-  Timestamp                = {2017.01.17},
-  Url                      = {www.mantidproject.org}
+@article{mantid,
+title = {Mantid---{D}ata analysis and visualization package for neutron scattering and $\mu$ {SR} experiments},
+journal = {Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment},
+volume = {764},
+pages = {156-166},
+year = {2014},
+issn = {0168-9002},
+doi = {10.1016/j.nima.2014.07.029},
+url = {https://www.sciencedirect.com/science/article/pii/S0168900214008729},
+author = {O. Arnold and J.C. Bilheux and J.M. Borreguero and A. Buts and S.I. Campbell and L. Chapon and M. Doucet and N. Draper and R. {Ferraz Leal} and M.A. Gigg and V.E. Lynch and A. Markvardsen and D.J. Mikkelson and R.L. Mikkelson and R. Miller and K. Palmen and P. Parker and G. Passos and T.G. Perring and P.F. Peterson and S. Ren and M.A. Reuter and A.T. Savici and J.W. Taylor and R.J. Taylor and R. Tolchenov and W. Zhou and J. Zikovsky},
+keywords = {Data analysis, Data visualization, Computer interfaces},
+abstract = {The Mantid framework is a software solution developed for the analysis and visualization of neutron scattering and muon spin measurements. The framework is jointly developed by software engineers and scientists at the ISIS Neutron and Muon Facility and the Oak Ridge National Laboratory. The objectives, functionality and novel design aspects of Mantid are described.}
 }
 
 @article{cutest,


### PR DESCRIPTION
#### Description of Work

Remove linting errors within the core directory.
The only linting messages remaining are refactor suggestions - too-many-nested-blocks and duplicate-code

The duplicate code looks to be boiler plate code in the tests

Fixes #767


#### Testing Instructions

1. Run pylint and flake8 on the core directory
2. Check the changes made

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
