### PR TITLE
Check pi as a value not a function for nist parser - is_safe method

### DIFF
--- a/fitbenchmarking/parsing/nist_data_functions.py
+++ b/fitbenchmarking/parsing/nist_data_functions.py
@@ -150,7 +150,7 @@ def is_safe(func_str):
 
     # These are all safe and can be stripped out
     if 'np' in func_str:
-        np_funcs = ['np.exp', 'np.cos', 'np.sin', 'np.tan', 'np.pi', 'np.log']
+        np_funcs = ['np.exp', 'np.cos', 'np.sin', 'np.tan', 'np.log']
         for s in np_funcs:
             func_str = func_str.replace(s, '')
 
@@ -211,6 +211,10 @@ def is_safe(func_str):
 
             # Return True if both sub parts are safe
             return is_safe(left) and is_safe(right)
+
+    # np.pi is acceptable
+    if func_str == 'np.pi':
+        return True
 
     # Floating points are acceptable
     try:


### PR DESCRIPTION
#### Description of Work

Fixes #601


#### Testing Instructions

1. Run is_safe for "np.pi*x"

Function: Does the change do what it's supposed to?
Tests: Does it pass? Is there adequate coverage for new code?
Style: Is the coding style consistent? Is anything overly confusing?
Documentation: Is there a suitable change to documentation for this change?
