### PR TITLE
Axes labels changed and sasview problem log plot

### DIFF
--- a/fitbenchmarking/results_processing/plots.py
+++ b/fitbenchmarking/results_processing/plots.py
@@ -83,11 +83,9 @@ class Plot:
         if self.problem.format == "sasview":
             self.ax.set_xscale("log", nonpositive='clip')
             self.ax.set_yscale("log", nonpositive='clip')
-            self.ax.set_xlabel("log(X)")
-            self.ax.set_ylabel("log(Y)")
-        else: # linear scale if otherwise
-            self.ax.set_xlabel("X")
-            self.ax.set_ylabel("Y")
+        # linear scale if otherwise
+        self.ax.set_xlabel("X")
+        self.ax.set_ylabel("Y")
         self.ax.set_title(self.result.name,
                           fontsize=self.title_size)
         self.ax.legend(loc=self.legend_location)

--- a/fitbenchmarking/results_processing/plots.py
+++ b/fitbenchmarking/results_processing/plots.py
@@ -79,8 +79,15 @@ class Plot:
         """
         Performs post plot processing to annotate the plot correctly
         """
-        self.ax.set_xlabel(r"Time ($\mu s$)")
-        self.ax.set_ylabel("Arbitrary units")
+        # log scale plot if problem is a SASView problem
+        if self.problem.format == "sasview":
+            self.ax.set_xscale("log", nonpositive='clip')
+            self.ax.set_yscale("log", nonpositive='clip')
+            self.ax.set_xlabel("log(X)")
+            self.ax.set_ylabel("log(Y)")
+        else: # linear scale if otherwise
+            self.ax.set_xlabel("X")
+            self.ax.set_ylabel("Y")
         self.ax.set_title(self.result.name,
                           fontsize=self.title_size)
         self.ax.legend(loc=self.legend_location)


### PR DESCRIPTION
#### Description of Work

To address issue #815. The x and y axes labels have been changed from "Time (\mu s)" and "Arbitrary Units" to "X" and "Y" respectively for all problem types other than SASView problems. If the problem is a SASView problem, the x and y axes become log (base 10) scaled.


#### Testing Instructions

1. Run any problem set to see the new plot axis labels
2. Run the SASView example problem set and see results plots for log plots
