### PR TITLE
Failed minimizers report - corrected typo

### DIFF
--- a/fitbenchmarking/templates/table_template.html
+++ b/fitbenchmarking/templates/table_template.html
@@ -87,7 +87,7 @@
                                 </ol>
                                 <p>
                                     This is likely due to the `algorithm_type` set in the options. Please review current options setup and re-run
-                                    FitBenmarking.
+                                    FitBenchmarking.
                                 </p>
                             {% endif %}
                             <h3>Errors</h3>


### PR DESCRIPTION
"FitBenmarking" replaced with "FitBenchmarking" see #845.