### PR TITLE
Add matlab_stats back to valid fitting

### DIFF
--- a/fitbenchmarking/utils/options.py
+++ b/fitbenchmarking/utils/options.py
@@ -58,7 +58,7 @@ class Options:
                             'gauss_newton', 'bfgs', 'conjugate_gradient',
                             'steepest_descent', 'global_optimization'],
          'software': ['bumps', 'dfo', 'gradient_free', 'gsl', 'levmar',
-                      'mantid', 'matlab', 'matlab_opt', 'matlab_opt',
+                      'mantid', 'matlab', 'matlab_opt', 'matlab_stats',
                       'minuit', 'ralfit', 'scipy', 'scipy_ls', 'scipy_go'],
          'jac_method': ['scipy', 'analytic', 'default', 'numdifftools'],
          'cost_func_type': ['nlls', 'weighted_nlls', 'hellinger_nlls',


### PR DESCRIPTION
#### Description of Work

Fixes #868 


#### Testing Instructions

1. Check that the matlab stats fitting software can now be run when selected in an options file

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
