### PR TITLE
Compare table concepts

### DIFF
--- a/fitbenchmarking/results_processing/compare_table.py
+++ b/fitbenchmarking/results_processing/compare_table.py
@@ -138,12 +138,48 @@ class CompareTable(Table):
         :return: list of HTML colours
         :rtype: list
         """
-        color_template = 'background-image: linear-gradient({0},{0},{1},{1})'
+        ######## OPTION 1: Linear Gradient ##########
+        # color_template = 'background-image: linear-gradient({0},{0},{1},{1})'
+        # name = value.name.split('"')[2].replace("</a>", "")[1:]
+        # output_colour = []
+        # acc_colour, runtime_colour = colour[name]
+        # for acc, runtime in zip(acc_colour, runtime_colour):
+        #     output_colour.append(color_template.format(acc, runtime))
+
+        ######## OPTION 2: Rectangular Vertical Runtime Bars ##########
+        color_template = 'background-image: linear-gradient(270deg, {0} 0% 25%, {1} 25% 100%),'\
+            'linear-gradient(0deg, {2} 0% {3}%, {1} {3}% 100%);'
         name = value.name.split('"')[2].replace("</a>", "")[1:]
         output_colour = []
+        results_dict = self.create_results_dict()
+        disp_results = self.get_values(results_dict)
+        _, rels = disp_results
+        rel_runtime = rels[name][1]
         acc_colour, runtime_colour = colour[name]
-        for acc, runtime in zip(acc_colour, runtime_colour):
-            output_colour.append(color_template.format(acc, runtime))
+        for acc_hex, runtime_hex, runtime in zip(acc_colour, runtime_colour, rel_runtime):
+            runtime_bar_length = ((runtime-min(rel_runtime))/\
+                (max(rel_runtime)-min(rel_runtime)))*100
+            h = acc_hex.lstrip('#')
+            rgb = str(tuple(int(h[i:i+2], 16) for i in (0, 2, 4))).rstrip(')')
+            output_colour.append(color_template.format('rgba'+rgb+',0)',\
+                 'rgba'+rgb+',1)', runtime_hex, runtime_bar_length))
+        
+        ######## OPTION 3: Triangular Runtime Bars ##########
+        # color_template = 'background-image: linear-gradient(135deg, {0} 0% {1}%, {2} {1}% 100%)'
+        # name = value.name.split('"')[2].replace("</a>", "")[1:]
+        # output_colour = []
+        # results_dict = self.create_results_dict()
+        # disp_results = self.get_values(results_dict)
+        # _, rels = disp_results
+        # rel_runtime = rels[name][1]
+        # acc_colour, runtime_colour = colour[name]
+        # for acc_hex, runtime_hex, runtime in zip(acc_colour, runtime_colour, rel_runtime):
+        #     runtime_bar_length = 100 - ((runtime-min(rel_runtime))/\
+        #         (max(rel_runtime)-min(rel_runtime)))*50
+        #     h = acc_hex.lstrip('#')
+        #     rgb = str(tuple(int(h[i:i+2], 16) for i in (0, 2, 4)))#.rstrip(')')
+        #     output_colour.append(color_template.format('rgb'+rgb,\
+        #          runtime_bar_length, runtime_hex))
         return output_colour
 
     def get_cbar(self, fig_dir):

--- a/fitbenchmarking/templates/table_style.css
+++ b/fitbenchmarking/templates/table_style.css
@@ -34,7 +34,7 @@ thead tr th.blank.level0 {
 }
 
 th, td {
-  border: 1px solid black;
+  border: 2px solid white;
 }
 
 th a, td a {


### PR DESCRIPTION
#### Description of Work

In response to #873, this branch was created to sample the aesthetic changes to the table that were intended to improve its readability to new users. This work was undertaken at the end of @BenPetersRAL's placement so it is a work in progress and created as a draft pull request and is just to show how the bars were generated. 

#### Testing Instructions

In `results_processing/compare_table.py`, see the `colour_highlight` method where there are three filling options for the cells as indicated in the inline comments. To keep this as a simple draft the original linear gradient and TWO runtime bar concepts comprise the options here. They can be switched by toggling commented lines only (draft form).

#### Future Work

Issue #873 details the feedback provided when the runtime bars concept was shown. It is advised that a way of making the bars always contrast with the text and the background of their cell is found, and that a reliable dynamically generated key be added that would provide a labelled example cell to explain the significance of the bar height and the background colour to users.