### PR TITLE
Add overflow hide back in

### DIFF
--- a/fitbenchmarking/templates/table_style.css
+++ b/fitbenchmarking/templates/table_style.css
@@ -35,6 +35,7 @@ thead tr th.blank.level0 {
 
 th, td {
   border: 1px solid black;
+  overflow: hidden;
 }
 
 th a, td a {


### PR DESCRIPTION
#### Description of Work
Reintroduce the `overflow: hidden;` line in the CSS which looks to have been removed accidentally during a previous change.
Fixes #875


#### Testing Instructions

1. Do the links work?
2. Does table scrolling still work?

Function: Does the change do what it's supposed to?
Tests: Does it pass? Is there adequate coverage for new code?
Style: Is the coding style consistent? Is anything overly confusing?
Documentation: Is there a suitable change to documentation for this change?
