### PR TITLE
Fix incorrect minimizer links

### DIFF
--- a/docs/source/users/options/minimizer_option.rst
+++ b/docs/source/users/options/minimizer_option.rst
@@ -81,8 +81,8 @@ The DFO minimizers are set as follows:
    See :ref:`extra_dependencies`.
 
 
-Gradient-Free-Optimizers (``gradient_free``)
----------------------------------------------
+Gradient-Free (``gradient_free``)
+---------------------------------
 
 `Gradient-Free-Optimizers <https://github.com/SimonBlanke/Gradient-Free-Optimizers>`_ are a collection of
 gradient-free methods capable of solving various optimization problems. Please note that Gradient-Free-Optimizers
@@ -279,8 +279,8 @@ The `matlab` minimizer is set as follows:
 .. warning::
    MATLAB must be installed for this to be available; See :ref:`external-instructions`.
 
-Matlab Curve Fitting Toolbox (``matlab_curve``)
------------------------------------------------
+Matlab Curve (``matlab_curve``)
+-------------------------------
 
 We call the `fit <https://uk.mathworks.com/help/curvefit/fit.html>`_
 function from the `MATLAB Curve Fitting Toolbox <https://uk.mathworks.com/help/curvefit/index.html>`_,
@@ -300,8 +300,8 @@ The `matlab_curve` minimizers are set as follows:
 .. warning::
    MATLAB Curve Fitting Toolbox must be installed for this to be available; See :ref:`external-instructions`.
 
-Matlab Optimization Toolbox (``matlab_opt``)
---------------------------------------------
+Matlab Opt (``matlab_opt``)
+---------------------------
 
 We call the `lsqcurvefit <https://uk.mathworks.com/help/optim/ug/lsqcurvefit.html>`_
 function from the `MATLAB Optimization Toolbox <https://uk.mathworks.com/products/optimization.html>`_,
@@ -322,8 +322,8 @@ The `matlab_opt` minimizers are set as follows:
    MATLAB Optimization Toolbox must be installed for this to be available; See :ref:`external-instructions`.
 
 
-Matlab Statistics Toolbox (``matlab_stats``)
---------------------------------------------
+Matlab Stats (``matlab_stats``)
+-------------------------------
 
 We call the `nlinfit <https://uk.mathworks.com/help/stats/nlinfit.html>`_
 function from the `MATLAB Statistics Toolbox <https://uk.mathworks.com/products/statistics.html>`_,


### PR DESCRIPTION
#### Description of Work

Fixes #864 

#### Testing Instructions

1. Check that the minimizer links in the results table now point to the correct fitting software from the Minimizer Options docs page

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
