### PR TITLE
Contributor Editable Installation Note

### DIFF
--- a/docs/source/contributors/install_instructions.rst
+++ b/docs/source/contributors/install_instructions.rst
@@ -16,6 +16,11 @@ for new contributors:
    code, you should install Fitbenchmarking from source. For
    details on how to do this, please see :ref:`installing_from_source`.
 
+   .. note::
+        The `editable` flag should be used when installing from source, like 
+        ``pip install -e ...``, so that changes made to the cloned code 
+        are immediately reflected in the imported package.
+
 3. So that you are able to run all tests locally, all extra dependencies and
    external software should be installed. Please see :ref:`extra_dependencies`
    and :ref:`external-instructions` for instructions on how to do this.

--- a/docs/source/users/install_instructions/externals.rst
+++ b/docs/source/users/install_instructions/externals.rst
@@ -40,7 +40,7 @@ Mantid
 
 Mantid is used both as fitting software, and to parse data files.
 
-Instructions on how to install Mantid for range of systems are available
+Instructions on how to install Mantid for a range of systems are available
 at `<https://download.mantidproject.org/>`_.
 
 MATLAB

--- a/docs/source/users/options/plotting_option.rst
+++ b/docs/source/users/options/plotting_option.rst
@@ -109,7 +109,7 @@ Options are:
 
 * ``acc`` indicates that the resulting table should contain the chi squared values for each of the minimizers.
 * ``runtime`` indicates that the resulting table should contain the runtime values for each of the minimizers.
-* ``compare`` indicates that the resulting table should contain both the chi squared value and runtime values for each of the minimizers. The tables produced have the chi squared values on the top line of the cell and the runtime on the bottom line of the cell.
+* ``compare`` indicates that the resulting table should contain both the chi squared value and runtime value for each of the minimizers. The tables produced have the chi squared values on the top line of the cell and the runtime on the bottom line of the cell.
 * ``local_min`` indicates that the resulting table should return true if a local minimum was found, or false otherwise.
   The value of :math:`\frac{|| J^T r||}{||r||}` for those parameters is also returned.
   The output looks like ``{bool} (norm_value)``, and the colouring is red for false and cream for true.


### PR DESCRIPTION
#### Description of Work
This PR adds a note to the contributor installation instructions mentioning that the editable `-e` flag should be used when installing from source as a contributor.

I also fixed a few minor typos I noticed when reading through the docs.

Fixes #916 

#### Testing Instructions
Read the documentation changes and make sure they make sense

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
