### PR TITLE
Use Relative Path for colourbar image

### DIFF
--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -558,4 +558,4 @@ class Table:
 
         plt.savefig(fig_path, dpi=150)
 
-        return fig_path
+        return os.path.relpath(fig_path, self.group_dir)

--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -518,7 +518,7 @@ class Table:
 
         return hex_strs
 
-    def save_colourbar(self, fig_dir, n_divs=100, sz_in=(3, 0.8)):
+    def save_colourbar(self, fig_dir, n_divs=100, sz_in=(3, 0.8)) -> str:
         """
         Generates a png of a labelled colourbar using matplotlib.
 
@@ -528,6 +528,9 @@ class Table:
         :type n_divs: int
         :param sz_in: dimensions of png in inches [width, height]
         :type sz_in: list[float] - 2 elements
+
+        :return: The relative path to the colourbar image.
+        :rtype: str
         """
         fig_path = os.path.join(fig_dir, "{0}_cbar.png".format(self.name))
 
@@ -554,3 +557,5 @@ class Table:
         fig.set_size_inches(sz_in[0], sz_in[1])
 
         plt.savefig(fig_path, dpi=150)
+
+        return fig_path

--- a/fitbenchmarking/results_processing/local_min_table.py
+++ b/fitbenchmarking/results_processing/local_min_table.py
@@ -173,7 +173,7 @@ class LocalMinTable(Table):
         return f'{str(local_min)} ({template.format(norm_rel)})'
 
     # pylint: disable=unused-argument
-    def save_colourbar(self, fig_dir, n_divs=2, sz_in=None):
+    def save_colourbar(self, fig_dir, n_divs=2, sz_in=None) -> str:
         """
         Override default save_colourbar as there are only 2 possible divisions
         of the colour map (true or false).
@@ -184,9 +184,12 @@ class LocalMinTable(Table):
         :type n_divs: int, Fixed to 2
         :param sz_in: dimensions of png in inches [width, height]
         :type sz_in: list[float] - 2 elements
+
+        :return: The relative path to the colourbar image.
+        :rtype: str
         """
         if sz_in is not None:
-            super().save_colourbar(fig_dir, n_divs=2, sz_in=sz_in)
+            return super().save_colourbar(fig_dir, n_divs=2, sz_in=sz_in)
         else:
-            super().save_colourbar(fig_dir, n_divs=2)
+            return super().save_colourbar(fig_dir, n_divs=2)
     # pylint: enable=unused-argument

--- a/fitbenchmarking/results_processing/tests/test_base_table.py
+++ b/fitbenchmarking/results_processing/tests/test_base_table.py
@@ -202,11 +202,9 @@ class DisplayStrTests(TestCase):
 
     def setUp(self):
         results = generate_results()
-        self.root_directory = os.path.join(os.path.dirname(__file__),
-                                           os.pardir, os.pardir, os.pardir)
         self.table = DummyTable(results=results,
                                 options=Options(),
-                                group_dir=self.root_directory,
+                                group_dir='fake',
                                 pp_locations=('no', 'pp'),
                                 table_name='A table!')
 
@@ -234,6 +232,22 @@ class DisplayStrTests(TestCase):
         s = self.table.display_str([7, 9])
         self.assertEqual(s, '9 (7)')
 
+
+class SaveColourbarTests(TestCase):
+    """
+    Tests for the save_colourbar implementation.
+    """
+
+    def setUp(self):
+        results = generate_results()
+        self.root_directory = os.path.join(os.path.dirname(__file__),
+                                           os.pardir, os.pardir, os.pardir)
+        self.table = DummyTable(results=results,
+                                options=Options(),
+                                group_dir=self.root_directory,
+                                pp_locations=('no', 'pp'),
+                                table_name='A table!')
+
     @mock.patch("fitbenchmarking.results_processing.base_table.plt.savefig")
     def test_save_colourbar_returns_a_relative_path(self, savefig_mock):
         """
@@ -246,8 +260,8 @@ class DisplayStrTests(TestCase):
         figure_directory = os.path.join(self.root_directory,
                                         figure_sub_directory)
 
-        relative_path = f"{figure_sub_directory}/{colourbar_file}"
-        save_path = self.table.save_colourbar(figure_directory)
-        self.assertEqual(save_path.replace("\\", "/"), relative_path)
+        relative_path = os.path.join(figure_sub_directory, colourbar_file)
+        self.assertEqual(self.table.save_colourbar(figure_directory),
+                         relative_path)
 
         savefig_mock.assert_called_once()

--- a/fitbenchmarking/results_processing/tests/test_base_table.py
+++ b/fitbenchmarking/results_processing/tests/test_base_table.py
@@ -4,6 +4,7 @@ Tests for functions in the base tables file.
 
 from unittest import TestCase
 
+import os
 import numpy as np
 
 from fitbenchmarking.cost_func.weighted_nlls_cost_func import \
@@ -201,9 +202,10 @@ class DisplayStrTests(TestCase):
 
     def setUp(self):
         results = generate_results()
+        self.root_directory = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
         self.table = DummyTable(results=results,
                                 options=Options(),
-                                group_dir='fake',
+                                group_dir=self.root_directory,
                                 pp_locations=('no', 'pp'),
                                 table_name='A table!')
 
@@ -230,3 +232,21 @@ class DisplayStrTests(TestCase):
         self.table.options.comparison_mode = 'both'
         s = self.table.display_str([7, 9])
         self.assertEqual(s, '9 (7)')
+
+    def test_save_colourbar_returns_the_relative_path_to_the_colourbar_figure(self):
+        """
+        Test the relative path to the colourbar figure is returned after saving.
+        """
+        self.table.name = "fake_name"
+        colourbar_file = f"{self.table.name}_cbar.png"
+
+        figure_sub_directory = "fitbenchmarking_results"
+        figure_directory = os.path.join(self.root_directory, figure_sub_directory)
+
+        full_path = f"{figure_directory}/{colourbar_file}"
+        relative_path = f"{figure_sub_directory}\\{colourbar_file}"
+
+        self.assertEqual(self.table.save_colourbar(figure_directory), relative_path)
+
+        self.assertTrue(os.path.exists(full_path))
+        os.remove(full_path)

--- a/fitbenchmarking/results_processing/tests/test_base_table.py
+++ b/fitbenchmarking/results_processing/tests/test_base_table.py
@@ -2,7 +2,7 @@
 Tests for functions in the base tables file.
 """
 
-from unittest import TestCase
+from unittest import mock, TestCase
 
 import os
 import numpy as np
@@ -202,7 +202,8 @@ class DisplayStrTests(TestCase):
 
     def setUp(self):
         results = generate_results()
-        self.root_directory = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir)
+        self.root_directory = os.path.join(os.path.dirname(__file__),
+                                           os.pardir, os.pardir, os.pardir)
         self.table = DummyTable(results=results,
                                 options=Options(),
                                 group_dir=self.root_directory,
@@ -233,20 +234,20 @@ class DisplayStrTests(TestCase):
         s = self.table.display_str([7, 9])
         self.assertEqual(s, '9 (7)')
 
-    def test_save_colourbar_returns_the_relative_path_to_the_colourbar_figure(self):
+    @mock.patch("fitbenchmarking.results_processing.base_table.plt.savefig")
+    def test_save_colourbar_returns_a_relative_path(self, savefig_mock):
         """
-        Test the relative path to the colourbar figure is returned after saving.
+        Test the relative path to the colourbar figure is returned after saving
         """
         self.table.name = "fake_name"
         colourbar_file = f"{self.table.name}_cbar.png"
 
         figure_sub_directory = "fitbenchmarking_results"
-        figure_directory = os.path.join(self.root_directory, figure_sub_directory)
+        figure_directory = os.path.join(self.root_directory,
+                                        figure_sub_directory)
 
-        full_path = f"{figure_directory}/{colourbar_file}"
-        relative_path = f"{figure_sub_directory}\\{colourbar_file}"
+        relative_path = f"{figure_sub_directory}/{colourbar_file}"
+        save_path = self.table.save_colourbar(figure_directory)
+        self.assertEqual(save_path.replace("\\", "/"), relative_path)
 
-        self.assertEqual(self.table.save_colourbar(figure_directory), relative_path)
-
-        self.assertTrue(os.path.exists(full_path))
-        os.remove(full_path)
+        savefig_mock.assert_called_once()


### PR DESCRIPTION
#### Description of Work
This PR fixes a bug where the colourbars that are saved were not being returned and so were said to be 'None' in the comparison page. It also ensures that the path to the colourbars is a relative path so the bug in the issue doesn't occur when ssh tunnelling to a different machine.

Fixes #911


#### Testing Instructions

1. Run a fitbenchmark of any problem. Open the results and you should see the colourbar is present instead of saying 'None'
2. Right click the colour bar and Inspect it. The path to the image should be relative.

![image](https://user-images.githubusercontent.com/40830825/133110930-f0c30194-4c13-4ada-ae2e-549455643f0c.png)


Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
