### PR TITLE
Add time units to runtime table description

### DIFF
--- a/fitbenchmarking/templates/table_descriptions.rst
+++ b/fitbenchmarking/templates/table_descriptions.rst
@@ -10,7 +10,7 @@ acc: End
 
 compare: Start
 
-The combined results show the accuracy in the first line of the cell and the runtime on the second line of the cell.
+The combined results show the accuracy in the first line of the cell, and the runtime on the second line of the cell measured in seconds (:math:`s`).
 
 compare: End
 


### PR DESCRIPTION
#### Description of Work
This PR adds the time units of the runtime to the documentation generated after doing a fit benchmark.

Fixes #897

#### Testing Instructions

1. Read the changes to the documentation and make sure they make sense.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
