### PR TITLE
Better Minimizer Link Handling

### DIFF
--- a/docs/source/users/options/minimizer_option.rst
+++ b/docs/source/users/options/minimizer_option.rst
@@ -316,7 +316,7 @@ The `matlab` minimizer is set as follows:
 .. _matlab-curve:
 
 Matlab Curve Fitting Toolbox (``matlab_curve``)
------------------------------------------------
+===============================================
 
 We call the `fit <https://uk.mathworks.com/help/curvefit/fit.html>`_
 function from the `MATLAB Curve Fitting Toolbox <https://uk.mathworks.com/help/curvefit/index.html>`_,

--- a/docs/source/users/options/minimizer_option.rst
+++ b/docs/source/users/options/minimizer_option.rst
@@ -16,6 +16,8 @@ the default list of minimizers unless otherwise stated.
    software is also set in :ref:`fitting_option` (either explicitly, or
    as a default option).
 
+.. _bumps:
+
 Bumps (:code:`bumps`)
 =====================
 
@@ -60,6 +62,7 @@ The Bumps minimizers are set as follows:
    `de` is not included in the default list of minimizers for bumps. To run this solver, you must
    explicitly set the minimizer as seen above.
 	   
+.. _dfo:
 
 DFO (``dfo``)
 =============
@@ -92,10 +95,10 @@ The DFO minimizers are set as follows:
    these to be available;
    See :ref:`extra_dependencies`.
 
+.. _gradient-free:
 
-
-Gradient-Free (``gradient_free``)
-=================================
+Gradient-Free-Optimizers (``gradient_free``)
+============================================
 
 `Gradient-Free-Optimizers <https://github.com/SimonBlanke/Gradient-Free-Optimizers>`__ are a collection of
 gradient-free methods capable of solving various optimization problems. Please note that Gradient-Free-Optimizers
@@ -155,6 +158,7 @@ The `gradient_free` minimizers are set as follows:
    so are not run by default when `gradient_free` software is selected. To run these minimizers you must
    explicity set them as seen above.
 
+.. _gsl:
 	 
 GSL (``gsl``)
 =============
@@ -210,8 +214,8 @@ The GSL minimizers are set as follows:
 .. warning::
    The external packages GSL and pygsl must be installed to use these minimizers.
 
-.. _MantidMinimizers:
-   
+.. _mantid:
+
 Mantid (``mantid``)
 ===================
 
@@ -260,6 +264,8 @@ The Mantid minimizers are set as follows:
 .. warning::
    The external package Mantid must be installed to use these minimizers.
 
+.. _levmar:
+
 Levmar (``levmar``)
 ===================
 
@@ -284,6 +290,7 @@ The `levmar` minimizer is set as follows:
    See :ref:`extra_dependencies`. This package also requires the BLAS and LAPACK
    libraries to be present on the system.
 
+.. _matlab:
 
 Matlab (``matlab``)
 ===================
@@ -306,8 +313,10 @@ The `matlab` minimizer is set as follows:
 .. warning::
    MATLAB must be installed for this to be available; See :ref:`external-instructions`.
 
-Matlab Curve (``matlab_curve``)
--------------------------------
+.. _matlab-curve:
+
+Matlab Curve Fitting Toolbox (``matlab_curve``)
+-----------------------------------------------
 
 We call the `fit <https://uk.mathworks.com/help/curvefit/fit.html>`_
 function from the `MATLAB Curve Fitting Toolbox <https://uk.mathworks.com/help/curvefit/index.html>`_,
@@ -329,9 +338,10 @@ The `matlab_curve` minimizers are set as follows:
 .. warning::
    MATLAB Curve Fitting Toolbox must be installed for this to be available; See :ref:`external-instructions`.
 
+.. _matlab-opt:
 
-Matlab Opt (``matlab_opt``)
-===========================
+Matlab Optimization Toolbox (``matlab_opt``)
+============================================
 
 We call the `lsqcurvefit <https://uk.mathworks.com/help/optim/ug/lsqcurvefit.html>`__
 function from the `MATLAB Optimization Toolbox <https://uk.mathworks.com/products/optimization.html>`__,
@@ -353,9 +363,10 @@ The `matlab_opt` minimizers are set as follows:
 .. warning::
    MATLAB Optimization Toolbox must be installed for this to be available; See :ref:`external-instructions`.
 
+.. _matlab-stats:
 
-Matlab Stats (``matlab_stats``)
-===============================
+Matlab Statistics Toolbox (``matlab_stats``)
+============================================
 
 
 We call the `nlinfit <https://uk.mathworks.com/help/stats/nlinfit.html>`__
@@ -376,6 +387,7 @@ The `matlab_stats` minimizer is set as follows:
 .. warning::
    MATLAB Statistics Toolbox must be installed for this to be available; See :ref:`external-instructions`.
 
+.. _minuit:
 	   
 Minuit (``minuit``)
 ===================
@@ -403,6 +415,7 @@ The Minuit minimizers are set as follows:
    The additional dependency Minuit must be installed for this to be available;
    See :ref:`extra_dependencies`.	 
 
+.. _ralfit:
     
 RALFit (``ralfit``)
 ===================
@@ -434,6 +447,8 @@ The RALFit minimizers are set as follows:
 
 .. warning::
    The external package RALFit must be installed to use these minimizers.
+
+.. _scipy:
 
 SciPy (``scipy``)
 =================
@@ -471,6 +486,8 @@ The SciPy minimizers are set as follows:
            TNC
            SLSQP
 
+.. _scipy-ls:
+
 SciPy LS (``scipy_ls``)
 =======================
 
@@ -495,6 +512,8 @@ The SciPy least squares minimizers are set as follows:
     scipy_ls: lm-scipy
               trf
               dogbox
+
+.. _scipy-go:
 
 SciPy GO (``scipy_go``)
 =======================

--- a/docs/source/users/problem_definition_files/native.rst
+++ b/docs/source/users/problem_definition_files/native.rst
@@ -17,7 +17,7 @@ Examples of native problems are:
 
 .. literalinclude:: ../../../../examples/benchmark_problems/Muon/Muon_HIFI_113856.txt
 
-.. literalinclude:: ../../../../examples/benchmark_problems/SAS_modelling/1D/prob_def_1.txt
+.. literalinclude:: ../../../../examples/benchmark_problems/SAS_modelling/SASView_Simple_Shapes_1D/1D_cylinder_neutron_def0.txt
 
 These examples show the basic structure in which the file starts with a comment
 indicating it is a FitBenchmark problem followed by key-value pairs. Available

--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -377,7 +377,7 @@ class Table:
         # Format the table headers
         link_template = '<a href="https://fitbenchmarking.readthedocs.io/'\
                         'en/latest/users/options/minimizer_option.html#'\
-                        '{0}-{0}" target="_blank">{0}</a>'
+                        '{0}" target="_blank">{0}</a>'
         minimizer_template = '<span title="{0}">{1}</span>'
 
         row = next(iter(self.sorted_results.values()))

--- a/fitbenchmarking/results_processing/tests/expected_results/acc.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/acc.html
@@ -19,7 +19,7 @@
   <thead>
     <tr>
       <th class="blank level0" >&nbsp;</th>
-      <th class="col_heading level0 col0" colspan="3"><a href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls-scipy-ls" target="_blank">scipy-ls</a></th>
+      <th class="col_heading level0 col0" colspan="3"><a href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">scipy-ls</a></th>
     </tr>
     <tr>
       <th class="blank level1" >&nbsp;</th>

--- a/fitbenchmarking/results_processing/tests/expected_results/compare.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/compare.html
@@ -22,7 +22,7 @@
   <thead>
     <tr>
       <th class="blank level0" >&nbsp;</th>
-      <th class="col_heading level0 col0" colspan="3"><a href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls-scipy-ls" target="_blank">scipy-ls</a></th>
+      <th class="col_heading level0 col0" colspan="3"><a href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">scipy-ls</a></th>
     </tr>
     <tr>
       <th class="blank level1" >&nbsp;</th>

--- a/fitbenchmarking/results_processing/tests/expected_results/local_min.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/local_min.html
@@ -7,7 +7,7 @@
   <thead>
     <tr>
       <th class="blank level0" >&nbsp;</th>
-      <th class="col_heading level0 col0" colspan="3"><a href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls-scipy-ls" target="_blank">scipy-ls</a></th>
+      <th class="col_heading level0 col0" colspan="3"><a href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">scipy-ls</a></th>
     </tr>
     <tr>
       <th class="blank level1" >&nbsp;</th>

--- a/fitbenchmarking/results_processing/tests/expected_results/runtime.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/runtime.html
@@ -13,7 +13,7 @@
   <thead>
     <tr>
       <th class="blank level0" >&nbsp;</th>
-      <th class="col_heading level0 col0" colspan="3"><a href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls-scipy-ls" target="_blank">scipy-ls</a></th>
+      <th class="col_heading level0 col0" colspan="3"><a href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">scipy-ls</a></th>
     </tr>
     <tr>
       <th class="blank level1" >&nbsp;</th>


### PR DESCRIPTION
#### Description of Work
This PR makes it so that we can have long-form names for the minimizers in the documentation without breaking the links between the results tables and these minimizers. There is more information on the implementation in the issue.

I also fixed a warning about a missing file when building the docs. I've left the fix in this PR as it was simple
![image](https://user-images.githubusercontent.com/40830825/134484245-60913049-4f24-47f1-af1d-aefc0fb75146.png)

Fixes #881

#### Testing Instructions

1. Checkout this branch
2. Build the docs `.\docs\make.bat html` (make sure you have sphinx and m2r2 pip installed)
2. Browse to and open the `docs\build\html\users\options\minimizer_option.html` file
3. Try linking to each minimizer software by putting `#<minimizer-name>` on the end of the opened html link. For software with a space in the name like scripy ls, use a dash in place of the space like `#scipy-ls`
4. They should each link to the relevant section correctly
5. Check if any of the minimizers could do with having a better long-form name in the documentation title.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
