### PR TITLE
Fix MaxRuntimeError wrong flag set

### DIFF
--- a/docs/source/users/options/minimizer_option.rst
+++ b/docs/source/users/options/minimizer_option.rst
@@ -231,7 +231,7 @@ It has support for a number of minimizers, most of which are from GSL.
 
 * `Levenberg-Marquardt MD <https://docs.mantidproject.org/nightly/fitting/fitminimizers/LevenbergMarquardtMD.html>`__ (:code:`Levenberg-MarquardtMD`) - An implementation of Levenberg-Marquardt intended for MD workspaces, where work is divided into chunks to achieve a greater efficiency for a large number of data points.
 
-* `Simplex <https://docs.mantidproject.org/nightly/fitting/fitminimizers/Simplex.html>`__ (:code:`simplex`)
+* `Simplex <https://docs.mantidproject.org/nightly/fitting/fitminimizers/Simplex.html>`__ (:code:`Simplex`)
 
 * `SteepestDescent <https://docs.mantidproject.org/nightly/fitting/fitminimizers/GradientDescent.html>`__ (:code:`SteepestDescent`)
 

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -533,12 +533,13 @@ def loop_over_hessians(controller, options, minimizer_name,
                 raise ControllerAttributeError(
                     "Either the computed runtime or chi_sq values "
                     "was a NaN.")
-        except MaxRuntimeError as ex:
-            LOGGER.warning(str(ex))
-            controller.flag = 6
         except Exception as ex:  # pylint: disable=broad-except
             LOGGER.warning(str(ex))
-            controller.flag = 3
+            # The MaxRuntimeError can sometimes be caught by the fitting
+            # software and re-raised as an ordinary Exception. So a separate
+            # except clause to set the flag will not work.
+            controller.flag = 6 if MaxRuntimeError.class_message in str(ex) \
+                else 3
 
         if controller.flag in [3, 6]:
             # If there was an exception, set the runtime and

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -249,7 +249,6 @@ def loop_over_fitting_software(cost_func, options, start_values_index,
     # exception and record the problem name if that is the case
     software_check = [np.isinf(v.chi_sq) for v in software_results]
     if all(software_check):
-        software_results = []
         problem_fails.append(cost_func.problem.name)
     results.extend(software_results)
 

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_software.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_software.py
@@ -167,8 +167,8 @@ class LoopOverSoftwareTests(unittest.TestCase):
     @unittest.mock.patch('{}.loop_over_minimizers'.format(FITTING_DIR))
     def test_run_software_all_failed_minimizers(self, loop_over_minimizers):
         """
-        Tests that when all minimizers raise and exception for a problem
-        that this is reported correctly
+        Tests that when all minimizers raise an exception for a problem, it
+        is reported correctly and no results are excluded.
         """
         self.count = 0
         self.minimizer_failed = {s: self.options.minimizers[s]
@@ -182,7 +182,7 @@ class LoopOverSoftwareTests(unittest.TestCase):
                                 [fitbm_result.FittingResult(**self.result_args)
                                  for i in range(self.dfo_len)]]
         loop_over_minimizers.side_effect = self.mock_func_call
-        expected_list_len = 0
+        expected_list_len = 10
         expected_problem_fails = self.problem_fails
         expected_minimizer_failed = self.minimizer_failed
         expected_minimizer_success = self.minimizer_success

--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -510,6 +510,7 @@ class Table:
         norm_vals = (log_vals - log_llim) /\
             (log_ulim - log_llim)
         norm_vals[norm_vals > 1] = 1  # applying upper cutoff
+        norm_vals[np.isnan(norm_vals)] = 1  # deal with nans
         # trimming colour map according to default/user input
         norm_vals = cmap_range[0] + \
             norm_vals*(cmap_range[1] - cmap_range[0])

--- a/fitbenchmarking/results_processing/performance_profiler.py
+++ b/fitbenchmarking/results_processing/performance_profiler.py
@@ -82,11 +82,11 @@ def plot(acc, runtime, fig_dir):
 
         step_values = []
         for value in profile_plot.values():
-            sorted_list = np.sort(value[~np.isnan(value)])
+            sorted_list = np.sort(_remove_nans(value))
             step_values.append(np.insert(sorted_list, 0, 0.0))
 
-        max_value = np.max([np.nanmax(v)
-                            for v in profile_plot.values()])
+        max_value = _find_maximum_value_for_profile_plot(profile_plot)
+
         linear_upper_limit = 10
 
         use_log_plot = True
@@ -152,6 +152,33 @@ def plot(acc, runtime, fig_dir):
         plt.savefig(this_filename, dpi=150)
 
     return figure_path
+
+
+def _find_maximum_value_for_profile_plot(profile_plot: dict) -> float:
+    """
+    Finds the maximum x value to use for a profile plot of multiple profiles.
+    Returns 0.0 if only Nan values exist.
+    """
+    profile_maxes = [_find_maximum_profile_value(values)
+                     for values in profile_plot.values()]
+    return max([value for value in profile_maxes if value is not None],
+               default=0.0)
+
+
+def _find_maximum_profile_value(profile_values: list) -> float:
+    """
+    Finds the maximum value in a list of profile x values. Nan values
+    are filtered out and None returned if no values are found.
+    """
+    non_nan_values = _remove_nans(profile_values)
+    return np.max(non_nan_values) if len(non_nan_values) > 0 else None
+
+
+def _remove_nans(values: list) -> list:
+    """
+    Removes all the nan values from the provided list.
+    """
+    return values[~np.isnan(values)]
 
 
 def create_plot(ax, step_values, solvers):

--- a/fitbenchmarking/results_processing/performance_profiler.py
+++ b/fitbenchmarking/results_processing/performance_profiler.py
@@ -81,11 +81,13 @@ def plot(acc, runtime, fig_dir):
         figure_path.append(this_filename)
 
         step_values = []
+        max_value = 0.0
         for value in profile_plot.values():
             sorted_list = np.sort(_remove_nans(value))
+            max_in_list = np.max(sorted_list) if len(sorted_list) > 0 else 0.0
+            if max_in_list > max_value:
+                max_value = max_in_list
             step_values.append(np.insert(sorted_list, 0, 0.0))
-
-        max_value = _find_maximum_value_for_profile_plot(profile_plot)
 
         linear_upper_limit = 10
 
@@ -154,29 +156,9 @@ def plot(acc, runtime, fig_dir):
     return figure_path
 
 
-def _find_maximum_value_for_profile_plot(profile_plot: dict) -> float:
+def _remove_nans(values: np.ndarray) -> np.ndarray:
     """
-    Finds the maximum x value to use for a profile plot of multiple profiles.
-    Returns 0.0 if only Nan values exist.
-    """
-    profile_maxes = [_find_maximum_profile_value(values)
-                     for values in profile_plot.values()]
-    return max([value for value in profile_maxes if value is not None],
-               default=0.0)
-
-
-def _find_maximum_profile_value(profile_values: list) -> float:
-    """
-    Finds the maximum value in a list of profile x values. Nan values
-    are filtered out and None returned if no values are found.
-    """
-    non_nan_values = _remove_nans(profile_values)
-    return np.max(non_nan_values) if len(non_nan_values) > 0 else None
-
-
-def _remove_nans(values: list) -> list:
-    """
-    Removes all the nan values from the provided list.
+    Removes all the nan values from the provided numpy array.
     """
     return values[~np.isnan(values)]
 

--- a/fitbenchmarking/results_processing/performance_profiler.py
+++ b/fitbenchmarking/results_processing/performance_profiler.py
@@ -82,10 +82,10 @@ def plot(acc, runtime, fig_dir):
 
         step_values = []
         for value in profile_plot.values():
-            sorted_list = np.sort(value)
+            sorted_list = np.sort(value[~np.isnan(value)])
             step_values.append(np.insert(sorted_list, 0, 0.0))
 
-        max_value = np.max([np.max(v)
+        max_value = np.max([np.nanmax(v)
                             for v in profile_plot.values()])
         linear_upper_limit = 10
 


### PR DESCRIPTION
#### Description of Work
This PR fixes a problem where the wrong flag was being set for a MaxRuntimeError when using certain software packages (such as mantid) when benchmarking.

This PR also makes it so that nan and inf results are now shown in the comparison table even when it is nan and inf for all minimizers trying to solve a given problem. I think this is a good idea because I found it confusing why certain results were not appearing as expected without a clear cause or warning.

Fixes #927

#### Testing Instructions

1. I fitted the SASView simple shape problems using the following options file
```
[FITTING]

software: mantid

num_runs: 1
max_runtime: 5

[MINIMIZERS]

bumps: lm-bumps
       mp

scipy_ls: lm-scipy

mantid: BFGS
        Levenberg-Marquardt

[PLOTTING]

make_plots: yes

[LOGGING]

external_output: log_only
```
2. The flag next to the two infs should be 6
![image](https://user-images.githubusercontent.com/40830825/134897542-12acc238-3e7f-4c1e-9f12-b0172932ed06.png)

3. If you comment out `Levenberg-Marquardt` in the options file and run again, you should still be able see them in the comparison table when you open the browser.
![image](https://user-images.githubusercontent.com/40830825/134897475-e7a53b89-3000-4ef4-aa83-3cb1f5bdac04.png)

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
