### PR TITLE
Run Unit tests in one call

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,7 @@ jobs:
         sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install -r requirements.txt
     - name: 'Running Tests'
       run: |
-        cd fitbenchmarking
-        ../ci/unit_tests_default.sh
+        ci/unit_tests_default.sh
         
   full_unit_linux:
     name: 'Full Unit Tests (Linux)'
@@ -83,8 +82,7 @@ jobs:
         mkdir -p $PYCUTEST_CACHE
     - name: 'Running Tests'
       run: |
-        cd fitbenchmarking
-        ../ci/unit_tests.sh
+        ci/unit_tests.sh
     - name: 'Submit Coverage'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -131,5 +129,4 @@ jobs:
         python -m pip install -r requirements.txt
     - name: 'Running Tests'
       run: |
-        cd fitbenchmarking
-        bash ../ci/unit_tests_default.sh
+        bash ci/unit_tests_default.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,8 @@ jobs:
         sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install -r requirements.txt
     - name: 'Running Tests'
       run: |
-        ci/unit_tests_default.sh
+        cd fitbenchmarking
+        ../ci/unit_tests_default.sh
         
   full_unit_linux:
     name: 'Full Unit Tests (Linux)'
@@ -82,7 +83,8 @@ jobs:
         mkdir -p $PYCUTEST_CACHE
     - name: 'Running Tests'
       run: |
-        ci/unit_tests.sh
+        cd fitbenchmarking
+        ../ci/unit_tests.sh
     - name: 'Submit Coverage'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -129,4 +131,5 @@ jobs:
         python -m pip install -r requirements.txt
     - name: 'Running Tests'
       run: |
-        bash ci/unit_tests_default.sh
+        cd fitbenchmarking
+        bash ../ci/unit_tests_default.sh

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -3,15 +3,9 @@
 /opt/Mantid/bin/mantidpython -m mantid.simpleapi >file 2>/dev/null | cat
 echo "first run of mantid is expected to segfault"
 
-# Test one dir to generate the coverage file
-pytest fitbenchmarking/cli --cov=fitbenchmarking/cli --cov-report term-missing
+cd fitbenchmarking
+pytest cli controllers core cost_func hessian jacobian parsing results_processing utils --cov=./ --cov-report term-missing
 status=$?
-# Loop over other dirs to append to the coverage file
-for dir in controllers core cost_func hessian jacobian parsing results_processing utils
-do
-    pytest fitbenchmarking/$dir --cov=fitbenchmarking/$dir --cov-report term-missing --cov-append
-    status=$(($status + $?))
-done
 
 if [[ $status != 0 ]]
 then

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -3,8 +3,10 @@
 /opt/Mantid/bin/mantidpython -m mantid.simpleapi >file 2>/dev/null | cat
 echo "first run of mantid is expected to segfault"
 
-DIRS="fitbenchmarking/cli fitbenchmarking/controllers fitbenchmarking/core fitbenchmarking/cost_func fitbenchmarking/hessian fitbenchmarking/jacobian fitbenchmarking/parsing fitbenchmarking/results_processing fitbenchmarking/utils"
-pytest $DIRS --cov=$DIRS --cov-report term-missing --cov-append
+DIRS="cli controllers core cost_func hessian jacobian parsing results_processing utils"
+for d in $DIRS; do FULL_DIRS="$FULL_DIRS fitbenchmarking/$d"; done
+for d in $FULL_DIRS; do COV_ARGS="$COV_ARGS --cov=$d"; done
+pytest $FULL_DIRS $COV_ARGS --cov-report term-missing
 status=$?
 
 if [[ $status != 0 ]]

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -3,7 +3,8 @@
 /opt/Mantid/bin/mantidpython -m mantid.simpleapi >file 2>/dev/null | cat
 echo "first run of mantid is expected to segfault"
 
-pytest cli controllers core cost_func hessian jacobian parsing results_processing utils --cov=./ --cov-report term-missing
+DIRS="fitbenchmarking/cli fitbenchmarking/controllers fitbenchmarking/core fitbenchmarking/cost_func fitbenchmarking/hessian fitbenchmarking/jacobian fitbenchmarking/parsing fitbenchmarking/results_processing fitbenchmarking/utils"
+pytest $DIRS --cov=$DIRS --cov-report term-missing
 status=$?
 
 if [[ $status != 0 ]]

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -4,7 +4,7 @@
 echo "first run of mantid is expected to segfault"
 
 DIRS="fitbenchmarking/cli fitbenchmarking/controllers fitbenchmarking/core fitbenchmarking/cost_func fitbenchmarking/hessian fitbenchmarking/jacobian fitbenchmarking/parsing fitbenchmarking/results_processing fitbenchmarking/utils"
-pytest $DIRS --cov=$DIRS --cov-report term-missing
+pytest $DIRS --cov=$DIRS --cov-report term-missing --cov-append
 status=$?
 
 if [[ $status != 0 ]]

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -3,7 +3,6 @@
 /opt/Mantid/bin/mantidpython -m mantid.simpleapi >file 2>/dev/null | cat
 echo "first run of mantid is expected to segfault"
 
-cd fitbenchmarking
 pytest cli controllers core cost_func hessian jacobian parsing results_processing utils --cov=./ --cov-report term-missing
 status=$?
 

--- a/ci/unit_tests_default.sh
+++ b/ci/unit_tests_default.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Test default installation
 cd fitbenchmarking
-pytest controllers core cost_func hessian jacobian parsing results_processing utils --cov=./ --cov-report term-missing --test-type default
+pytest cli controllers core cost_func hessian jacobian parsing results_processing utils --cov=./ --cov-report term-missing --test-type default
 status=$?
 
 if [[ $status != 0 ]]

--- a/ci/unit_tests_default.sh
+++ b/ci/unit_tests_default.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Test default installation
-DIRS="fitbenchmarking/cli fitbenchmarking/controllers fitbenchmarking/core fitbenchmarking/cost_func fitbenchmarking/hessian fitbenchmarking/jacobian fitbenchmarking/parsing fitbenchmarking/results_processing fitbenchmarking/utils"
-pytest $DIRS --cov=$DIRS --cov-report term-missing --cov-append --test-type default
+DIRS="cli controllers core cost_func hessian jacobian parsing results_processing utils"
+for d in $DIRS; do FULL_DIRS="$FULL_DIRS fitbenchmarking/$d"; done
+for d in $FULL_DIRS; do COV_ARGS="$COV_ARGS --cov=$d"; done
+pytest $FULL_DIRS $COV_ARGS --cov-report term-missing --test-type default
 status=$?
 
 if [[ $status != 0 ]]

--- a/ci/unit_tests_default.sh
+++ b/ci/unit_tests_default.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Test default installation
 DIRS="fitbenchmarking/cli fitbenchmarking/controllers fitbenchmarking/core fitbenchmarking/cost_func fitbenchmarking/hessian fitbenchmarking/jacobian fitbenchmarking/parsing fitbenchmarking/results_processing fitbenchmarking/utils"
-pytest $DIRS --cov=$DIRS --cov-report term-missing --test-type default
+pytest $DIRS --cov=$DIRS --cov-report term-missing --cov-append --test-type default
 status=$?
 
 if [[ $status != 0 ]]

--- a/ci/unit_tests_default.sh
+++ b/ci/unit_tests_default.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Test default installation
-pytest cli controllers core cost_func hessian jacobian parsing results_processing utils --cov=./ --cov-report term-missing --test-type default
+DIRS="fitbenchmarking/cli fitbenchmarking/controllers fitbenchmarking/core fitbenchmarking/cost_func fitbenchmarking/hessian fitbenchmarking/jacobian fitbenchmarking/parsing fitbenchmarking/results_processing fitbenchmarking/utils"
+pytest $DIRS --cov=$DIRS --cov-report term-missing --test-type default
 status=$?
 
 if [[ $status != 0 ]]

--- a/ci/unit_tests_default.sh
+++ b/ci/unit_tests_default.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # Test default installation
-cd fitbenchmarking
 pytest cli controllers core cost_func hessian jacobian parsing results_processing utils --cov=./ --cov-report term-missing --test-type default
 status=$?
 

--- a/ci/unit_tests_default.sh
+++ b/ci/unit_tests_default.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 # Test default installation
-pytest fitbenchmarking/cli --cov=fitbenchmarking/cli --cov-report term-missing
+cd fitbenchmarking
+pytest controllers core cost_func hessian jacobian parsing results_processing utils --cov=./ --cov-report term-missing --test-type default
 status=$?
-for dir in controllers core cost_func hessian jacobian parsing results_processing utils
-do
-    pytest fitbenchmarking/$dir --test-type default
-    status=$(($status + $?))
-done
+
 if [[ $status != 0 ]]
 then
    exit 1


### PR DESCRIPTION
#### Description of Work
This PR ensures the unit tests are run in one `pytest` call. This should hopefully make it easier to read the test output because there will only be one list of test failures rather than a number of different lists that you need to search for.

Fixes #955

#### Testing Instructions

1. Check that the unit tests still run and that there is only one `pytest` call

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
