### PR TITLE
Pylint - Fail on refactor and convention warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,7 @@ disable=too-many-instance-attributes,
 output-format=colorized
 
 # Tells whether to display a full report or only the messages.
-reports=yes
+reports=no
 
 [VARIABLES]
 
@@ -37,10 +37,11 @@ ignored-argument-names=arg|args|kwargs
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=mantid,
-                ral_nlls,
+ignored-modules=levmar,
+                mantid,
                 matlab,
-                levmar
+                pygsl,
+                ral_nlls
 
 [DESIGN]
 

--- a/ci/linting_tests.sh
+++ b/ci/linting_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pylint fitbenchmarking || pylint-exit $? --error-fail --warn-fail
+pylint fitbenchmarking || pylint-exit $? --error-fail --warn-fail --refactor-fail --convention-fail
 status=$?
 
 flake8 fitbenchmarking

--- a/fitbenchmarking/cli/main.py
+++ b/fitbenchmarking/cli/main.py
@@ -89,8 +89,9 @@ of the Fitbenchmarking docs. '''
 def _find_options_file(options_file: str, results_directory: str) -> Options:
     """
     Attempts to find the options file and creates an Options object for it.
+    Wildcards are accepted in the parameters of this function.
 
-    :param options_file: The path to an options file.
+    :param options_file: The path or glob pattern for an options file.
     :type options_file: str
     :param results_directory: The path to the results directory.
     :type results_directory: str
@@ -117,12 +118,12 @@ def _create_index_page(options: Options, groups: "list[str]",
     Creates the results index page for the benchmark, and copies
     the fonts and js directories to the correct location.
 
-    :param options: The options object containing all the options.
+    :param options: The user options for the benchmark.
     :type options: fitbenchmarking.utils.options.Options
-    :param groups: A list of problem set group names.
+    :param groups: Names for each of the problem set groups.
     :type groups: A list of strings.
-    :param result_directories: A list of directories to the results of
-    different problem sets.
+    :param result_directories: Result directory paths for each
+    problem set group.
     :type result_directories: A list of strings.
     :return: The filepath of the `results_index.html` file.
     :rtype: str

--- a/fitbenchmarking/cli/tests/test_main.py
+++ b/fitbenchmarking/cli/tests/test_main.py
@@ -31,6 +31,29 @@ def make_cost_function(file_name='cubic.dat', minimizers=None):
     return cost_func
 
 
+def mock_func_call(*args, **kwargs):
+    """
+    Mock function to be used instead of benchmark
+    """
+    options = Options()
+    cost_func = make_cost_function()
+
+    results = []
+    result_args = {'options': options,
+                   'cost_func': cost_func,
+                   'jac': 'jac',
+                   'hess': 'hess',
+                   'initial_params': [],
+                   'params': [],
+                   'error_flag': 4}
+    result = fitbm_result.FittingResult(**result_args)
+    results.append(result)
+
+    failed_problems = []
+    unselected_minimizers = {}
+    return results, failed_problems, unselected_minimizers
+
+
 class TestMain(TestCase):
     """
     Tests for main.py
@@ -52,30 +75,8 @@ class TestMain(TestCase):
         """
         Checks that exception is raised if all dummy results
         """
-        benchmark.side_effect = self.mock_func_call
+        benchmark.side_effect = mock_func_call
 
         with self.assertRaises(exceptions.NoResultsError):
             main.run(['examples/benchmark_problems/simple_tests'],
                      os.path.dirname(__file__), debug=True)
-
-    def mock_func_call(self, *args, **kwargs):
-        """
-        Mock function to be used instead of benchmark
-        """
-        options = Options()
-        cost_func = make_cost_function()
-
-        results = []
-        result_args = {'options': options,
-                       'cost_func': cost_func,
-                       'jac': 'jac',
-                       'hess': 'hess',
-                       'initial_params': [],
-                       'params': [],
-                       'error_flag': 4}
-        result = fitbm_result.FittingResult(**result_args)
-        results.append(result)
-
-        failed_problems = []
-        unselected_minimzers = {}
-        return (results, failed_problems, unselected_minimzers)

--- a/fitbenchmarking/controllers/gsl_controller.py
+++ b/fitbenchmarking/controllers/gsl_controller.py
@@ -211,7 +211,6 @@ class GSLController(Controller):
         """
         Run problem with GSL
         """
-        # pylint: disable=c-extension-no-member
         for _ in range(self._maxits):
             status = self._solver.iterate()
             # check if the method has converged
@@ -236,7 +235,6 @@ class GSLController(Controller):
                 self.flag = 2
         else:
             self.flag = 1
-        # pylint: enable=c-extension-no-member
 
     def cleanup(self):
         """

--- a/fitbenchmarking/controllers/gsl_controller.py
+++ b/fitbenchmarking/controllers/gsl_controller.py
@@ -211,6 +211,7 @@ class GSLController(Controller):
         """
         Run problem with GSL
         """
+        # pylint: disable=c-extension-no-member
         for _ in range(self._maxits):
             status = self._solver.iterate()
             # check if the method has converged
@@ -235,6 +236,7 @@ class GSLController(Controller):
                 self.flag = 2
         else:
             self.flag = 1
+        # pylint: enable=c-extension-no-member
 
     def cleanup(self):
         """

--- a/fitbenchmarking/controllers/scipy_go_controller.py
+++ b/fitbenchmarking/controllers/scipy_go_controller.py
@@ -5,7 +5,7 @@ problems.
 """
 
 import numpy as np
-import scipy.optimize as optimize
+from scipy import optimize
 
 from fitbenchmarking.controllers.base_controller import Controller
 from fitbenchmarking.utils.exceptions import MissingBoundsError

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -90,11 +90,12 @@ class DummyController(Controller):
 
 
 class ControllerSharedTesting:
-    '''
+    """
     Tests used by all controllers
-    '''
+    """
 
-    def controller_run_test(self, controller):
+    @staticmethod
+    def controller_run_test(controller):
         """
         Utility function to run controller and check output is in generic form
 
@@ -108,7 +109,8 @@ class ControllerSharedTesting:
 
         assert len(controller.final_params) == len(controller.initial_params)
 
-    def check_converged(self, controller):
+    @staticmethod
+    def check_converged(controller):
         """
         Utility function to check controller.cleanup() produces a success flag
 
@@ -118,7 +120,8 @@ class ControllerSharedTesting:
         controller.cleanup()
         assert controller.flag == 0
 
-    def check_max_iterations(self, controller):
+    @staticmethod
+    def check_max_iterations(controller):
         """
         Utility function to check controller.cleanup() produces a maximum
         iteration flag
@@ -129,7 +132,8 @@ class ControllerSharedTesting:
         controller.cleanup()
         assert controller.flag == 1
 
-    def check_diverged(self, controller):
+    @staticmethod
+    def check_diverged(controller):
         """
         Utility function to check controller.cleanup() produces a fail
 
@@ -477,8 +481,8 @@ class ControllerBoundsTests(TestCase):
         controller.cleanup()
 
         for count, value in enumerate(controller.final_params):
-            assert controller.value_ranges[count][0] <= value \
-                <= controller.value_ranges[count][1]
+            self.assertLessEqual(controller.value_ranges[count][0], value)
+            self.assertGreaterEqual(controller.value_ranges[count][1], value)
 
     def test_scipy(self):
         """
@@ -565,6 +569,9 @@ class ControllerBoundsTests(TestCase):
 
 @run_for_test_types(TEST_TYPE, 'all')
 class ControllerValidateTests(TestCase):
+    """
+    Tests to ensure controller data is validated correctly.
+    """
 
     def setUp(self):
         """

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -497,7 +497,6 @@ def loop_over_hessians(controller, options, minimizer_name, grabbed_output):
     minimizer = controller.minimizer
     cost_func = controller.cost_func
     problem = controller.problem
-    num_runs = options.num_runs
     minimizer_check = minimizer in controller.hessian_enabled_solvers
     hessian_list = options.hes_method
     new_result = []
@@ -526,7 +525,7 @@ def loop_over_hessians(controller, options, minimizer_name, grabbed_output):
                 LOGGER.warning(str(excp))
 
         # Perform the fit a number of times specified by num_runs
-        chi_sq, runtime = perform_fit(controller, num_runs, grabbed_output)
+        chi_sq, runtime = perform_fit(controller, options, grabbed_output)
 
         # record algorithm type for specified minimizer
         type_str = controller.record_alg_type(
@@ -564,18 +563,21 @@ def loop_over_hessians(controller, options, minimizer_name, grabbed_output):
     return new_result, new_chi_sq, new_minimizer_list
 
 
-def perform_fit(controller, num_runs, grabbed_output):
+def perform_fit(controller, options, grabbed_output):
     """
     Performs a fit using the provided controller and its data. It
     will be run a number of times specified by num_runs.
 
     :param controller: The software controller for the fitting
     :type controller: Object derived from BaseSoftwareController
-    :param num_runs: The number of times to repeat the fit.
-    :type num_runs: int
+    :param options: The user options for the benchmark.
+    :type options: fitbenchmarking.utils.options.Options
     :param grabbed_output: Object that removes third part output from console
     :type grabbed_output: fitbenchmarking.utils.output_grabber.OutputGrabber
+    :return: The chi squared and runtime of the fit.
+    :rtype: tuple(chi_squared, runtime)
     """
+    num_runs = options.num_runs
     try:
         with grabbed_output:
             controller.validate()

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -575,7 +575,7 @@ def perform_fit(controller, options, grabbed_output):
     :param grabbed_output: Object that removes third part output from console
     :type grabbed_output: fitbenchmarking.utils.output_grabber.OutputGrabber
     :return: The chi squared and runtime of the fit.
-    :rtype: tuple(chi_squared, runtime)
+    :rtype: tuple(float, float)
     """
     num_runs = options.num_runs
     try:

--- a/fitbenchmarking/core/tests/test_results_output.py
+++ b/fitbenchmarking/core/tests/test_results_output.py
@@ -272,8 +272,9 @@ class CreatePlotsTests(unittest.TestCase):
         """
         Setting up paths and results folders
         """
-        self.tempdir = TemporaryDirectory()
-        self.results_dir = os.path.join(self.tempdir.name, 'figures_dir')
+        with TemporaryDirectory() as file:
+            self.results_dir = os.path.join(file.name, 'figures_dir')
+
         results, self.options = generate_mock_results(self.results_dir)
         self.best_results, self.results = preprocess_data(results)
 

--- a/fitbenchmarking/core/tests/test_results_output.py
+++ b/fitbenchmarking/core/tests/test_results_output.py
@@ -273,7 +273,7 @@ class CreatePlotsTests(unittest.TestCase):
         Setting up paths and results folders
         """
         with TemporaryDirectory() as file:
-            self.results_dir = os.path.join(file.name, 'figures_dir')
+            self.results_dir = os.path.join(file, 'figures_dir')
 
         results, self.options = generate_mock_results(self.results_dir)
         self.best_results, self.results = preprocess_data(results)

--- a/fitbenchmarking/core/tests/test_results_output.py
+++ b/fitbenchmarking/core/tests/test_results_output.py
@@ -275,8 +275,8 @@ class CreatePlotsTests(unittest.TestCase):
         with TemporaryDirectory() as directory:
             self.results_dir = os.path.join(directory, 'figures_dir')
 
-        results, self.options = generate_mock_results(self.results_dir)
-        self.best_results, self.results = preprocess_data(results)
+            results, self.options = generate_mock_results(self.results_dir)
+            self.best_results, self.results = preprocess_data(results)
 
     @mock.patch('fitbenchmarking.results_processing.plots.Plot')
     def test_create_plots_with_params(self, plot_mock):
@@ -440,15 +440,15 @@ class ExtractTagsTests(unittest.TestCase):
         """
         with TemporaryDirectory() as directory:
             self.results_dir = os.path.join(directory, 'figures_dir')
-        results, self.options = generate_mock_results(self.results_dir)
-        self.result = results[0]
-        self.result.costfun_tag = 'cf0'
-        self.result.problem_tag = 'p0'
-        self.result.software_tag = 's0'
-        self.result.minimizer_tag = 'm0'
-        self.result.jacobian_tag = 'j0'
-        self.result.hessian_tag = 'h0'
-        self.result.error_flag = 0
+            results, self.options = generate_mock_results(self.results_dir)
+            self.result = results[0]
+            self.result.costfun_tag = 'cf0'
+            self.result.problem_tag = 'p0'
+            self.result.software_tag = 's0'
+            self.result.minimizer_tag = 'm0'
+            self.result.jacobian_tag = 'j0'
+            self.result.hessian_tag = 'h0'
+            self.result.error_flag = 0
 
     def test_correct_tags(self):
         """
@@ -522,14 +522,14 @@ class ProcessBestResultsTests(unittest.TestCase):
         """
         with TemporaryDirectory() as directory:
             self.results_dir = os.path.join(directory, 'figures_dir')
-        results, self.options = generate_mock_results(self.results_dir)
-        self.results = results[:5]
-        for r, chisq, runtime in zip(self.results,
-                                     [2, 1, 5, 3, 4],
-                                     [5, 4, 1, 2, 3]):
-            r.chi_sq = chisq
-            r.runtime = runtime
-        self.best = _process_best_results(self.results)
+            results, self.options = generate_mock_results(self.results_dir)
+            self.results = results[:5]
+            for r, chisq, runtime in zip(self.results,
+                                         [2, 1, 5, 3, 4],
+                                         [5, 4, 1, 2, 3]):
+                r.chi_sq = chisq
+                r.runtime = runtime
+            self.best = _process_best_results(self.results)
 
     def test_returns_best_result(self):
         """

--- a/fitbenchmarking/core/tests/test_results_output.py
+++ b/fitbenchmarking/core/tests/test_results_output.py
@@ -272,8 +272,8 @@ class CreatePlotsTests(unittest.TestCase):
         """
         Setting up paths and results folders
         """
-        with TemporaryDirectory() as file:
-            self.results_dir = os.path.join(file, 'figures_dir')
+        with TemporaryDirectory() as directory:
+            self.results_dir = os.path.join(directory, 'figures_dir')
 
         results, self.options = generate_mock_results(self.results_dir)
         self.best_results, self.results = preprocess_data(results)
@@ -438,8 +438,8 @@ class ExtractTagsTests(unittest.TestCase):
         """
         Setup function for extract tags tests.
         """
-        self.tempdir = TemporaryDirectory()
-        self.results_dir = os.path.join(self.tempdir.name, 'figures_dir')
+        with TemporaryDirectory() as directory:
+            self.results_dir = os.path.join(directory, 'figures_dir')
         results, self.options = generate_mock_results(self.results_dir)
         self.result = results[0]
         self.result.costfun_tag = 'cf0'
@@ -520,8 +520,8 @@ class ProcessBestResultsTests(unittest.TestCase):
         """
         Setup function for _process_best_results tests.
         """
-        self.tempdir = TemporaryDirectory()
-        self.results_dir = os.path.join(self.tempdir.name, 'figures_dir')
+        with TemporaryDirectory() as directory:
+            self.results_dir = os.path.join(directory, 'figures_dir')
         results, self.options = generate_mock_results(self.results_dir)
         self.results = results[:5]
         for r, chisq, runtime in zip(self.results,

--- a/fitbenchmarking/jacobian/analytic_jacobian.py
+++ b/fitbenchmarking/jacobian/analytic_jacobian.py
@@ -5,7 +5,6 @@ from fitbenchmarking.jacobian.base_jacobian import Jacobian
 from fitbenchmarking.utils.exceptions import NoJacobianError
 
 
-# pylint: disable=useless-super-delegation
 class Analytic(Jacobian):
     """
     Class to apply an analytical Jacobian

--- a/fitbenchmarking/jacobian/default_jacobian.py
+++ b/fitbenchmarking/jacobian/default_jacobian.py
@@ -4,7 +4,6 @@ Module which uses the minimizer's default jacobian
 from fitbenchmarking.jacobian.base_jacobian import Jacobian
 
 
-# pylint: disable=useless-super-delegation
 class Default(Jacobian):
     """
     Use the minimizer's jacobian/derivative approximation

--- a/fitbenchmarking/jacobian/scipy_jacobian.py
+++ b/fitbenchmarking/jacobian/scipy_jacobian.py
@@ -7,7 +7,6 @@ from scipy.optimize._numdiff import approx_derivative
 from fitbenchmarking.jacobian.base_jacobian import Jacobian
 
 
-# pylint: disable=useless-super-delegation
 class Scipy(Jacobian):
     """
     Implements SciPy finite difference approximations to the derivative

--- a/fitbenchmarking/parsing/fitbenchmark_parser.py
+++ b/fitbenchmarking/parsing/fitbenchmark_parser.py
@@ -15,7 +15,6 @@ from fitbenchmarking.utils.log import get_logger
 LOGGER = get_logger()
 
 
-# pylint: disable=too-many-branches
 class FitbenchmarkParser(Parser):
     """
     Parser for the native FitBenchmarking problem definition (FitBenchmark)

--- a/fitbenchmarking/parsing/fitbenchmark_parser.py
+++ b/fitbenchmarking/parsing/fitbenchmark_parser.py
@@ -164,8 +164,8 @@ class FitbenchmarkParser(Parser):
             self.fitting_problem.start_x = fit_ranges[0]['x'][0]
             self.fitting_problem.end_x = fit_ranges[0]['x'][1]
 
-    @staticmethod
-    def _set_additional_info() -> None:
+    def _set_additional_info(self) -> None:
+        # pylint: disable=no-self-use
         """
         Sets any additional info for a fitting problem.
         """

--- a/fitbenchmarking/parsing/fitbenchmark_parser.py
+++ b/fitbenchmarking/parsing/fitbenchmark_parser.py
@@ -165,7 +165,8 @@ class FitbenchmarkParser(Parser):
             self.fitting_problem.start_x = fit_ranges[0]['x'][0]
             self.fitting_problem.end_x = fit_ranges[0]['x'][1]
 
-    def _set_additional_info(self) -> None:
+    @staticmethod
+    def _set_additional_info() -> None:
         """
         Sets any additional info for a fitting problem.
         """

--- a/fitbenchmarking/parsing/fitting_problem.py
+++ b/fitbenchmarking/parsing/fitting_problem.py
@@ -72,7 +72,7 @@ class FittingProblem:
         #: e.g.
         #: :code:`[{p1_name: p1_val1, p2_name: p2_val1, ...},
         #: {p1_name: p1_val2, ...}, ...]`
-        self.starting_values = None
+        self.starting_values: list = None
 
         #: *list*
         #: Smallest and largest values of interest in the data

--- a/fitbenchmarking/parsing/fitting_problem.py
+++ b/fitbenchmarking/parsing/fitting_problem.py
@@ -72,7 +72,7 @@ class FittingProblem:
         #: e.g.
         #: :code:`[{p1_name: p1_val1, p2_name: p2_val1, ...},
         #: {p1_name: p1_val2, ...}, ...]`
-        self.starting_values: list = None
+        self.starting_values: list = []
 
         #: *list*
         #: Smallest and largest values of interest in the data
@@ -139,7 +139,6 @@ class FittingProblem:
         :rtype: list of str
         """
         if self._param_names is None:
-            # pylint: disable=unsubscriptable-object
             self._param_names = list(self.starting_values[0].keys())
         return self._param_names
 
@@ -235,7 +234,6 @@ class FittingProblem:
                             :code:`{p1_name: [p1_min, p1_max], ...}`
         :type value_ranges: dict
         """
-        # pylint: disable=unsubscriptable-object
         lower_param_names = [name.lower()
                              for name in self.starting_values[0].keys()]
         if not all(name in lower_param_names for name in value_ranges):

--- a/fitbenchmarking/parsing/ivp_parser.py
+++ b/fitbenchmarking/parsing/ivp_parser.py
@@ -10,10 +10,10 @@ import sys
 import typing
 import numpy as np
 
+from scipy.integrate import solve_ivp
+
 from fitbenchmarking.parsing.fitbenchmark_parser import FitbenchmarkParser
 from fitbenchmarking.utils.exceptions import ParsingError
-
-from scipy.integrate import solve_ivp
 
 
 class IVPParser(FitbenchmarkParser):

--- a/fitbenchmarking/parsing/mantid_parser.py
+++ b/fitbenchmarking/parsing/mantid_parser.py
@@ -10,7 +10,6 @@ import mantid.simpleapi as msapi
 from fitbenchmarking.parsing.fitbenchmark_parser import FitbenchmarkParser
 
 
-# pylint: disable=too-many-branches
 class MantidParser(FitbenchmarkParser):
     """
     Parser for a Mantid problem definition file.

--- a/fitbenchmarking/parsing/mantid_parser.py
+++ b/fitbenchmarking/parsing/mantid_parser.py
@@ -5,9 +5,9 @@ from collections import OrderedDict
 
 import typing
 
-from fitbenchmarking.parsing.fitbenchmark_parser import FitbenchmarkParser
-
 import mantid.simpleapi as msapi
+
+from fitbenchmarking.parsing.fitbenchmark_parser import FitbenchmarkParser
 
 
 # pylint: disable=too-many-branches

--- a/fitbenchmarking/parsing/nist_parser.py
+++ b/fitbenchmarking/parsing/nist_parser.py
@@ -191,7 +191,8 @@ class NISTParser(Parser):
 
         return equation_text, idx
 
-    def _get_equation_text(self, lines, idxerr, idx):
+    @staticmethod
+    def _get_equation_text(lines, idxerr, idx):
         """
         Gets the equation text from the NIST file.
 
@@ -220,7 +221,8 @@ class NISTParser(Parser):
 
         return equation_text, idx
 
-    def _get_data_txt(self, lines, idx):
+    @staticmethod
+    def _get_data_txt(lines, idx):
         """
         Gets the data pattern from the NIST problem file.
 
@@ -232,8 +234,6 @@ class NISTParser(Parser):
         :return: The data pattern and the new index
         :rtype: (list of str) and int
         """
-
-        data_text = None
         data_text = lines[idx:]
         idx = len(lines)
 
@@ -271,7 +271,8 @@ class NISTParser(Parser):
 
         return data_points
 
-    def _sort_data_from_x_data(self, data_points):
+    @staticmethod
+    def _sort_data_from_x_data(data_points):
         """
         Sort the numpy array of the data points of the problem
         using its x data.
@@ -309,7 +310,8 @@ class NISTParser(Parser):
         equation = self._convert_nist_to_muparser(equation)
         return equation
 
-    def _convert_nist_to_muparser(self, equation):
+    @staticmethod
+    def _convert_nist_to_muparser(equation):
         """
         Converts the raw equation from the NIST file into muparser format.
 
@@ -376,7 +378,8 @@ class NISTParser(Parser):
 
         return starting_vals
 
-    def _get_startvals_floats(self, startval_str):
+    @staticmethod
+    def _get_startvals_floats(startval_str):
         """
         Converts the starting values into floats.
 

--- a/fitbenchmarking/parsing/sasview_parser.py
+++ b/fitbenchmarking/parsing/sasview_parser.py
@@ -3,11 +3,11 @@ This file implements a parser for the SASView data format.
 """
 import typing
 
-from fitbenchmarking.parsing.fitbenchmark_parser import FitbenchmarkParser
-
 from sasmodels.bumps_model import Experiment, Model
 from sasmodels.core import load_model
 from sasmodels.data import empty_data1D
+
+from fitbenchmarking.parsing.fitbenchmark_parser import FitbenchmarkParser
 
 
 class SASViewParser(FitbenchmarkParser):

--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -138,8 +138,8 @@ class Table:
         return os.path.relpath(path=result.support_page_link,
                                start=self.group_dir)
 
-    def get_error_str(self, result, error_template='[{}]'):
-        # pylint: disable=no-self-use
+    @staticmethod
+    def get_error_str(result, error_template='[{}]'):
         """
         Get the error string for a result based on error_template
         This can be overridden if tables require different error formatting.

--- a/fitbenchmarking/results_processing/local_min_table.py
+++ b/fitbenchmarking/results_processing/local_min_table.py
@@ -198,3 +198,4 @@ class LocalMinTable(Table):
         if sz_in is not None:
             return super().save_colourbar(fig_dir, n_divs=2, sz_in=sz_in)
         return super().save_colourbar(fig_dir, n_divs=2)
+    # pylint: enable=unused-argument

--- a/fitbenchmarking/results_processing/local_min_table.py
+++ b/fitbenchmarking/results_processing/local_min_table.py
@@ -135,9 +135,9 @@ class LocalMinTable(Table):
 
         return local_min, norm_rel
 
-    # pylint: disable=unused-argument
     @staticmethod
     def vals_to_colour(vals, cmap, cmap_range, log_ulim):
+        # pylint: disable=unused-argument
         """
         Converts an array of values to a list of hexadecimal colour strings
         using sampling from a matplotlib colourmap according to whether a
@@ -161,7 +161,6 @@ class LocalMinTable(Table):
         rgba = cmap([cmap_range[0] if local_min else cmap_range[1]
                      for local_min in vals])
         return [clrs.rgb2hex(colour) for colour in rgba]
-    # pylint: enable=unused-argument
 
     def display_str(self, value):
         """
@@ -198,4 +197,3 @@ class LocalMinTable(Table):
         if sz_in is not None:
             return super().save_colourbar(fig_dir, n_divs=2, sz_in=sz_in)
         return super().save_colourbar(fig_dir, n_divs=2)
-    # pylint: enable=unused-argument

--- a/fitbenchmarking/results_processing/performance_profiler.py
+++ b/fitbenchmarking/results_processing/performance_profiler.py
@@ -8,8 +8,9 @@ import matplotlib
 import numpy as np
 
 matplotlib.use('Agg')
-# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-position,ungrouped-imports
 import matplotlib.pyplot as plt  # noqa: E402
+# pylint: enable=wrong-import-position,ungrouped-imports
 
 
 def profile(results, fig_dir):

--- a/fitbenchmarking/results_processing/tables.py
+++ b/fitbenchmarking/results_processing/tables.py
@@ -82,17 +82,12 @@ def create_results_tables(options, results, best_results, group_dir, fig_dir,
                 del table_names[suffix]
                 continue
 
-            table_title = table.table_title
             file_path = table.file_path
 
             description = table.get_description(description)
 
             table_format = None if suffix == 'local_min' \
                 else description[options.comparison_mode]
-
-            has_pp = table.has_pp
-
-            pp_filenames = table.pp_filenames
 
             root = os.path.dirname(getfile(fitbenchmarking))
             template_dir = os.path.join(root, 'templates')
@@ -116,9 +111,9 @@ def create_results_tables(options, results, best_results, group_dir, fig_dir,
                                     mathjax=js['mathjax'],
                                     table_description=description[suffix],
                                     table_format=table_format,
-                                    result_name=table_title,
-                                    has_pp=has_pp,
-                                    pp_filenames=pp_filenames,
+                                    result_name=table.table_title,
+                                    has_pp=table.has_pp,
+                                    pp_filenames=table.pp_filenames,
                                     table=html_table,
                                     cbar=cbar,
                                     error_message=ERROR_OPTIONS,

--- a/fitbenchmarking/results_processing/tests/test_base_table.py
+++ b/fitbenchmarking/results_processing/tests/test_base_table.py
@@ -18,7 +18,6 @@ from fitbenchmarking.utils.fitbm_result import FittingResult
 from fitbenchmarking.utils.options import Options
 
 
-# pylint: disable=unsubscriptable-object
 def generate_results():
     """
     Create a predictable set of results.
@@ -133,7 +132,6 @@ def generate_results():
 
     best_results = {'prob_0': {'cf1': results['prob_0']['cf1'][0]},
                     'prob_1': {'cf1': results['prob_1']['cf1'][0]}}
-
     return results, best_results
 
 

--- a/fitbenchmarking/results_processing/tests/test_problem_summary_page.py
+++ b/fitbenchmarking/results_processing/tests/test_problem_summary_page.py
@@ -151,13 +151,12 @@ class CreateTests(TestCase):
         """
         Setup for create function tests
         """
-        self.results_dir = TemporaryDirectory()
-        self.supp_dir = os.path.join(self.results_dir.name, 'support_pages')
-        self.fig_dir = os.path.join(self.supp_dir, 'figures')
+        with TemporaryDirectory() as directory:
+            directory_name = directory
+            self.supp_dir = os.path.join(directory_name, 'support_pages')
+            self.fig_dir = os.path.join(self.supp_dir, 'figures')
         os.makedirs(self.fig_dir)
-        results, self.options = generate_mock_results(
-            self.results_dir.name
-        )
+        results, self.options = generate_mock_results(directory_name)
         self.best_results, self.results = preprocess_data(results)
 
     def test_create_all_plots(self):
@@ -215,12 +214,13 @@ class CreateSummaryPageTests(TestCase):
         """
         Setup tests for _create_summary_page
         """
-        self.results_dir = TemporaryDirectory()
-        self.supp_dir = os.path.join(self.results_dir.name, 'support_pages')
+        with TemporaryDirectory() as directory:
+            directory_name = directory
+            self.supp_dir = os.path.join(directory_name, 'support_pages')
+
         os.makedirs(self.supp_dir)
-        results, self.options = generate_mock_results(
-            self.results_dir.name
-        )
+        results, self.options = generate_mock_results(directory_name)
+
         best_results, results = preprocess_data(results)
         self.prob_name = list(results.keys())[0]
         self.results = results[self.prob_name]

--- a/fitbenchmarking/results_processing/tests/test_problem_summary_page.py
+++ b/fitbenchmarking/results_processing/tests/test_problem_summary_page.py
@@ -6,6 +6,7 @@ import os
 from tempfile import TemporaryDirectory
 from unittest import TestCase, main
 
+import shutil
 import numpy as np
 
 from fitbenchmarking.core.results_output import preprocess_data
@@ -159,6 +160,12 @@ class CreateTests(TestCase):
         results, self.options = generate_mock_results(directory_name)
         self.best_results, self.results = preprocess_data(results)
 
+    def tearDown(self) -> None:
+        """
+        Tear down the test suite.
+        """
+        shutil.rmtree(self.fig_dir)
+
     def test_create_all_plots(self):
         """
         Check that a plot is created for each result set.
@@ -232,6 +239,12 @@ class CreateSummaryPageTests(TestCase):
             summary_plot_path='plot_path',
             support_pages_dir=self.supp_dir,
             options=self.options)
+
+    def tearDown(self) -> None:
+        """
+        Tear down the test suite.
+        """
+        shutil.rmtree(self.supp_dir)
 
     def test_create_summary_pages(self):
         """

--- a/fitbenchmarking/results_processing/tests/test_problem_summary_page.py
+++ b/fitbenchmarking/results_processing/tests/test_problem_summary_page.py
@@ -153,18 +153,18 @@ class CreateTests(TestCase):
         Setup for create function tests
         """
         with TemporaryDirectory() as directory:
-            directory_name = directory
-            self.supp_dir = os.path.join(directory_name, 'support_pages')
+            self.temp_dir = directory
+            self.supp_dir = os.path.join(self.temp_dir, 'support_pages')
             self.fig_dir = os.path.join(self.supp_dir, 'figures')
         os.makedirs(self.fig_dir)
-        results, self.options = generate_mock_results(directory_name)
+        results, self.options = generate_mock_results(self.temp_dir)
         self.best_results, self.results = preprocess_data(results)
 
     def tearDown(self) -> None:
         """
         Tear down the test suite.
         """
-        shutil.rmtree(self.fig_dir)
+        shutil.rmtree(self.temp_dir)
 
     def test_create_all_plots(self):
         """
@@ -222,11 +222,11 @@ class CreateSummaryPageTests(TestCase):
         Setup tests for _create_summary_page
         """
         with TemporaryDirectory() as directory:
-            directory_name = directory
-            self.supp_dir = os.path.join(directory_name, 'support_pages')
+            self.temp_dir = directory
+            self.supp_dir = os.path.join(self.temp_dir, 'support_pages')
 
         os.makedirs(self.supp_dir)
-        results, self.options = generate_mock_results(directory_name)
+        results, self.options = generate_mock_results(self.temp_dir)
 
         best_results, results = preprocess_data(results)
         self.prob_name = list(results.keys())[0]
@@ -244,7 +244,7 @@ class CreateSummaryPageTests(TestCase):
         """
         Tear down the test suite.
         """
-        shutil.rmtree(self.supp_dir)
+        shutil.rmtree(self.temp_dir)
 
     def test_create_summary_pages(self):
         """

--- a/fitbenchmarking/utils/tests/test_misc.py
+++ b/fitbenchmarking/utils/tests/test_misc.py
@@ -19,20 +19,13 @@ class CreateDirsTests(unittest.TestCase):
     Tests for the file and directory setting in misc.py
     """
 
-    def base_path(self):
-        """
-        Helper function that returns the path to
-        /fitbenchmarking/benchmark_problems
-        """
-        bench_prob_dir = os.path.dirname(inspect.getfile(mock_problems))
-        return bench_prob_dir
-
     def setUp(self):
         """
         Create some datafiles to look for.
         """
-        self.dirname = os.path.join(self.base_path(),
-                                    'mock_datasets_{}'.format(time.time()))
+        base_path = os.path.dirname(inspect.getfile(mock_problems))
+        self.dirname = os.path.join(base_path,
+                                    f"mock_datasets_{time.time()}")
         os.mkdir(self.dirname)
 
         expected = []

--- a/fitbenchmarking/utils/tests/test_options_generic.py
+++ b/fitbenchmarking/utils/tests/test_options_generic.py
@@ -132,7 +132,8 @@ class OptionsWriteTests(unittest.TestCase):
         opts_file = 'test_options_tests_valid.ini'
         with open(opts_file, 'w') as f:
             f.write(config_str)
-        Options(opts_file)
+        options = Options(opts_file)
+        self.assertEqual(options.stored_file_name, opts_file)
         os.remove(opts_file)
 
     def test_user_section_invalid(self):

--- a/fitbenchmarking/utils/tests/test_options_generic.py
+++ b/fitbenchmarking/utils/tests/test_options_generic.py
@@ -76,8 +76,8 @@ class OptionsWriteTests(unittest.TestCase):
 
         os.remove(new_file_name)
 
-        assert options.stored_file_name == self.options_file
-        assert new_options.stored_file_name == new_file_name
+        self.assertEqual(options.stored_file_name, self.options_file)
+        self.assertEqual(new_options.stored_file_name, new_file_name)
 
         # Overwrite file names
         options.stored_file_name = ""
@@ -92,15 +92,13 @@ class OptionsWriteTests(unittest.TestCase):
         options = Options(file_name=self.options_file)
         new_file_name = 'copy_of_{}'.format(self.options_file)
 
-        # open stream, write to it and close it
-        f = open(new_file_name, 'w')
-        options.write_to_stream(f)
-        f.close()
+        with open(new_file_name, 'w') as f:
+            options.write_to_stream(f)
 
         new_options = Options(new_file_name)
 
-        assert options.stored_file_name == self.options_file
-        assert new_options.stored_file_name == new_file_name
+        self.assertEqual(options.stored_file_name, self.options_file)
+        self.assertEqual(new_options.stored_file_name, new_file_name)
 
         # Overwrite file names
         options.stored_file_name = ""

--- a/fitbenchmarking/utils/tests/test_options_minimizers.py
+++ b/fitbenchmarking/utils/tests/test_options_minimizers.py
@@ -97,6 +97,7 @@ class MininimizerOptionTests(unittest.TestCase):
         self.assertEqual(expected, actual)
 
 
+# pylint: disable=too-many-public-methods
 class UserMininimizerOptionTests(unittest.TestCase):
     """
     Checks the minimizers in the options file are set correctly or raise errors


### PR DESCRIPTION
#### Description of Work
This PR is an attempt to squash all refactor and convention warnings seen in the pylint output. The motivation for doing this is so that it is easier to read the failures that relate to your PR. It also ensures unwanted refactor or convention practises do not get into the code base.

Fixes #957

#### Testing Instructions

1. Ensure the pylint job passes. Read the output of the pylint and make sure there are no convention or refactor warnings.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
