### PR TITLE
Fix Mantid MultiFit results when using more than one Jacobian/Hessian

### DIFF
--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -378,10 +378,9 @@ def loop_over_minimizers(controller, minimizers, options, grabbed_output):
                                                           options,
                                                           grabbed_output)
 
-            for result in results:
-                results_problem.append(fitbm_result.FittingResult(**result))
-
+            results_problem.extend(results)
             new_minimizer_list.extend(minimizer_list)
+
     return results_problem, minimizer_failed, new_minimizer_list
 
 
@@ -398,7 +397,7 @@ def loop_over_jacobians(controller, options, grabbed_output):
 
     :return: all results as a dictionary of arguments for FittingResult, and
              composite minimizer-jacobian-hessian names.
-    :rtype: list[dict],
+    :rtype: list[fibenchmarking.utils.fitbm_result.FittingResult],
             list[str]
     """
     cost_func = controller.cost_func
@@ -466,7 +465,7 @@ def loop_over_hessians(controller, options, minimizer_name, grabbed_output):
 
     :return: all results as a dictionary of arguments for FittingResult, and
              composite minimizer-jacobian-hessian names.
-    :rtype: list[dict],
+    :rtype: list[fibenchmarking.utils.fitbm_result.FittingResult],
             list[str]
     """
     minimizer = controller.minimizer
@@ -534,9 +533,9 @@ def loop_over_hessians(controller, options, minimizer_name, grabbed_output):
                 result_args.update(
                     {'dataset_id': i,
                      'name': f'{problem.name}, Dataset {i + 1}'})
-                new_result.append(result_args.copy())
+                new_result.append(fitbm_result.FittingResult(**result_args))
         else:
-            new_result.append(result_args)
+            new_result.append(fitbm_result.FittingResult(**result_args))
 
         # For minimizers that do not accept hessians we raise an
         # StopIteration exception to exit the loop through the

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_hessians.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_hessians.py
@@ -115,7 +115,7 @@ class LoopOverHessiansTests(unittest.TestCase):
         self.controller.minimizer = "general"
         new_name = ['general, analytic hessian']
         minimizer_name = "general"
-        _, _, new_minimizer_list = \
+        _, new_minimizer_list = \
             loop_over_hessians(self.controller,
                                self.options,
                                minimizer_name,
@@ -131,7 +131,7 @@ class LoopOverHessiansTests(unittest.TestCase):
         self.controller.minimizer = "deriv_free_algorithm"
         new_name = ['deriv_free_algorithm']
         minimizer_name = "deriv_free_algorithm"
-        _, _, new_minimizer_list = \
+        _, new_minimizer_list = \
             loop_over_hessians(self.controller,
                                self.options,
                                minimizer_name,
@@ -188,9 +188,9 @@ class LoopOverHessiansTests(unittest.TestCase):
         self.controller.parameter_set = 0
 
         self.controller.minimizer = "deriv_free_algorithm"
-        results, _, _ = loop_over_hessians(self.controller, self.options,
-                                           self.controller.minimizer,
-                                           self.grabbed_output)
+        results, _ = loop_over_hessians(self.controller, self.options,
+                                        self.controller.minimizer,
+                                        self.grabbed_output)
         self.assertEqual(results[0]["error_flag"], 6)
 
 

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_hessians.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_hessians.py
@@ -191,7 +191,7 @@ class LoopOverHessiansTests(unittest.TestCase):
         results, _ = loop_over_hessians(self.controller, self.options,
                                         self.controller.minimizer,
                                         self.grabbed_output)
-        self.assertEqual(results[0]["error_flag"], 6)
+        self.assertEqual(results[0].error_flag, 6)
 
 
 if __name__ == "__main__":

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_jacobians.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_jacobians.py
@@ -105,7 +105,7 @@ class LoopOverJacobiansTests(unittest.TestCase):
         Mock function to be used instead of loop_over_hessians
         """
         minimizer_name = args[2]
-        return [], [], [minimizer_name]
+        return [], [minimizer_name]
 
     @patch('{}.loop_over_hessians'.format(FITTING_DIR))
     def test_single_jacobian(self, loop_over_hessians):

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_jacobians.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_jacobians.py
@@ -117,7 +117,7 @@ class LoopOverJacobiansTests(unittest.TestCase):
         self.controller.minimizer = "general"
         loop_over_hessians.side_effect = self.mock_func_call
         new_name = ['general: scipy 3-point']
-        _, _, new_minimizer_list = \
+        _, new_minimizer_list = \
             loop_over_jacobians(self.controller,
                                 self.options,
                                 self.grabbed_output)
@@ -133,7 +133,7 @@ class LoopOverJacobiansTests(unittest.TestCase):
         self.controller.minimizer = "general"
         loop_over_hessians.side_effect = self.mock_func_call
         new_name = ['general: scipy 3-point', 'general: scipy 2-point']
-        _, _, new_minimizer_list = \
+        _, new_minimizer_list = \
             loop_over_jacobians(self.controller,
                                 self.options,
                                 self.grabbed_output)
@@ -150,7 +150,7 @@ class LoopOverJacobiansTests(unittest.TestCase):
         self.controller.minimizer = "deriv_free_algorithm"
         loop_over_hessians.side_effect = self.mock_func_call
         new_name = ['deriv_free_algorithm']
-        _, _, new_minimizer_list = \
+        _, new_minimizer_list = \
             loop_over_jacobians(self.controller,
                                 self.options,
                                 self.grabbed_output)

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_minimizers.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_minimizers.py
@@ -133,7 +133,7 @@ class LoopOverMinimizersTests(unittest.TestCase):
         Tests that some minimizers are selected
         """
         self.options.algorithm_type = ["general"]
-        self.results = [[self.result_args]]
+        self.results = [[fitbm_result.FittingResult(**self.result_args)]]
         self.minimizer_list = [["general"]]
         loop_over_hessians.side_effect = self.mock_func_call
 
@@ -150,7 +150,8 @@ class LoopOverMinimizersTests(unittest.TestCase):
         """
         Tests that all minimizers are selected
         """
-        self.results = [[self.result_args], [self.result_args]]
+        self.results = [[fitbm_result.FittingResult(**self.result_args)],
+                        [fitbm_result.FittingResult(**self.result_args)]]
         self.minimizer_list = [["general"], ["deriv_free_algorithm"]]
         loop_over_hessians.side_effect = self.mock_func_call
 

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_minimizers.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_minimizers.py
@@ -98,13 +98,10 @@ class LoopOverMinimizersTests(unittest.TestCase):
         self.grabbed_output = output_grabber.OutputGrabber(self.options)
         self.controller.parameter_set = 0
         self.count = 0
-        self.result_args = {'options': self.options,
-                            'cost_func': self.cost_func,
-                            'jac': "jac",
-                            'hess': 'hess',
-                            'initial_params': self.problem.starting_values[0],
-                            'params': [],
-                            'chi_sq': 1}
+        self.result = fitbm_result.FittingResult(
+            options=self.options, cost_func=self.cost_func, jac="jac",
+            hess="hess", initial_params=self.problem.starting_values[0],
+            params=[], chi_sq=1)
 
     def mock_func_call(self, *args, **kwargs):
         """
@@ -133,7 +130,7 @@ class LoopOverMinimizersTests(unittest.TestCase):
         Tests that some minimizers are selected
         """
         self.options.algorithm_type = ["general"]
-        self.results = [[fitbm_result.FittingResult(**self.result_args)]]
+        self.results = [[self.result]]
         self.minimizer_list = [["general"]]
         loop_over_hessians.side_effect = self.mock_func_call
 
@@ -150,8 +147,7 @@ class LoopOverMinimizersTests(unittest.TestCase):
         """
         Tests that all minimizers are selected
         """
-        self.results = [[fitbm_result.FittingResult(**self.result_args)],
-                        [fitbm_result.FittingResult(**self.result_args)]]
+        self.results = [[self.result], [self.result]]
         self.minimizer_list = [["general"], ["deriv_free_algorithm"]]
         loop_over_hessians.side_effect = self.mock_func_call
 

--- a/fitbenchmarking/core/tests/test_fitting_benchmarking_minimizers.py
+++ b/fitbenchmarking/core/tests/test_fitting_benchmarking_minimizers.py
@@ -113,7 +113,7 @@ class LoopOverMinimizersTests(unittest.TestCase):
         results = self.results[self.count]
         minimizer_list = self.minimizer_list[self.count]
         self.count += 1
-        return results, self.chi_sq, minimizer_list
+        return results, minimizer_list
 
     def test_run_minimzers_none_selected(self):
         """
@@ -134,7 +134,6 @@ class LoopOverMinimizersTests(unittest.TestCase):
         """
         self.options.algorithm_type = ["general"]
         self.results = [[self.result_args]]
-        self.chi_sq = 1
         self.minimizer_list = [["general"]]
         loop_over_hessians.side_effect = self.mock_func_call
 
@@ -152,7 +151,6 @@ class LoopOverMinimizersTests(unittest.TestCase):
         Tests that all minimizers are selected
         """
         self.results = [[self.result_args], [self.result_args]]
-        self.chi_sq = [1]
         self.minimizer_list = [["general"], ["deriv_free_algorithm"]]
         loop_over_hessians.side_effect = self.mock_func_call
 

--- a/fitbenchmarking/systests/linux_expected_results/multifit.txt
+++ b/fitbenchmarking/systests/linux_expected_results/multifit.txt
@@ -1,4 +1,4 @@
-                                                      mantid
-                          Levenberg-Marquardt: scipy 2-point
-Basic MultiFit, Dataset 1                           8.16 (1)
-Basic MultiFit, Dataset 2                          15.28 (1)
+                                                      mantid                                   
+                          Levenberg-Marquardt: scipy 2-point Levenberg-Marquardt: scipy 3-point
+Basic MultiFit, Dataset 1                           8.16 (1)                           8.16 (1)
+Basic MultiFit, Dataset 2                          15.28 (1)                          15.28 (1)


### PR DESCRIPTION
#### Description of Work
This PR fixes an issue where the results for a Mantid MultiFit would not be created when the multi fit is done using a number of different jacobians or hessians. There used to be an exceptions saying the program was exiting due to unknown exception, but now it opens the browser and displays the results as expected.

Fixes #920

#### Testing Instructions

1. Use the options file below to run the following command 
`fitbenchmarking -p examples/benchmark_problems/MultiFit/ -o examples/test_multi_fit.ini`

```
[FITTING]

software: mantid

num_runs: 1
max_runtime: 600

[MINIMIZERS]

mantid: Levenberg-Marquardt

[JACOBIAN]
scipy: 2-point
       3-point

[PLOTTING]

make_plots: yes

[OUTPUT]

results_dir: new_results/

[LOGGING]

external_output: log_only
```

2. You should get something like this

![image](https://user-images.githubusercontent.com/40830825/142407247-90b6af3d-acaf-4767-bc2d-aab961c9b5f8.png)


Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
