### PR TITLE
Update Minimum Python Version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: 'Choose Python Version'
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.8'
 
     - name: 'Build'
       run: |

--- a/docs/source/users/install_instructions/fitbenchmarking.rst
+++ b/docs/source/users/install_instructions/fitbenchmarking.rst
@@ -4,7 +4,7 @@
 Installing FitBenchmarking and default fitting packages
 #######################################################
 
-We recommend using |Python 3.6+| for running/installing Fitbenchmarking.
+We recommend using |Python 3.7.1+| for running/installing Fitbenchmarking.
 The easiest way to install FitBenchmarking is by using the Python package manager,
 `pip <https://pip.pypa.io/en/stable/>`__.
 
@@ -88,7 +88,7 @@ where valid strings ``option-x`` are:
 * ``numdifftools`` -- installs the `numdifftools <https://numdifftools.readthedocs.io/en/latest/index.html>`_ numerical differentiation package.
 
 
-.. |Python 3.6+| image:: https://img.shields.io/badge/python-3.6+-blue.svg
-   :alt: Python 3.6+
+.. |Python 3.7.1+| image:: https://img.shields.io/badge/python-3.7.1+-blue.svg
+   :alt: Python 3.7.1+
    :target: https://www.python.org/downloads/
 


### PR DESCRIPTION
#### Description of Work
Updates the minimum python version in the docs to be 3.7.1. It also updates the release workflow to use python 3.8 (the same python version as used in main.yml and the first major version above 3.7.1).

Fixes #986

#### Testing Instructions

1. Check that installation works with python 3.7.1

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
