### PR TITLE
Load problem descriptions for `NIST`, `Mantid`, `SASView` and `IVP` 

### DIFF
--- a/docs/source/users/problem_definition_files/native.rst
+++ b/docs/source/users/problem_definition_files/native.rst
@@ -46,8 +46,8 @@ name
 description
   A description of the dataset.
 
-  This is currently unused within FitBenchmarking, but can be useful for
-  explaining problems.
+  This will be displayed in the Problem Summary Pages and Fitting Reports produced by a
+  benchmark.
 
 input_file
   The name of a file containing the data to fit.

--- a/examples/benchmark_problems/simple_tests/cubic-fb.txt
+++ b/examples/benchmark_problems/simple_tests/cubic-fb.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we interpolate points that lie exactly on a cubic polynomial.
+description = 'This is a simple test problem where we interpolate points that lie exactly on a cubic polynomial.'
 software = 'mantid'
 name = 'cubic-fb'
 input_file = 'cubic.txt'
 function ='name=UserFunction, Formula=A1+A2*x+A3*x^2+A4*x^3, A1=0.0, A2=0.0, A3=0.0, A4=0.0'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/cubic-fba.txt
+++ b/examples/benchmark_problems/simple_tests/cubic-fba.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we interpolate points that lie exactly on a cubic polynomial.
+description = 'This is a simple test problem where we interpolate points that lie exactly on a cubic polynomial.'
 software = 'mantid'
 name = 'cubic-fba'
 input_file = 'cubic.txt'
 function ='name=UserFunction, Formula=A1+A2*x+A3*x^2+A4*x^3, A1=4.01, A2=2.98, A3=2.01, A4=1.02'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/gauss_exact-fb.txt
+++ b/examples/benchmark_problems/simple_tests/gauss_exact-fb.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we fit a curve to a Gaussian.
+description = 'This is a simple test problem where we fit a curve to a Gaussian.'
 software = 'Mantid'
 name = 'gauss-exact-fb'
 input_file = 'gauss-exact.txt'
 function = 'name=UserFunction, Formula=A1*exp( -( (A2-x)^2 / (2* (A3^2) ) ) ), A1=0.0, A2=0.0, A3=1.0'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/gauss_exact-fba.txt
+++ b/examples/benchmark_problems/simple_tests/gauss_exact-fba.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we fit a curve to a Gaussian.
+description = 'This is a simple test problem where we fit a curve to a Gaussian.'
 software = 'Mantid'
 name = 'gauss-exact-fba'
 input_file = 'gauss-exact.txt'
 function = 'name=UserFunction, Formula=A1*exp( -( (A2-x)^2 / (2* (A3^2) ) ) ), A1=1.0, A2=-3.0, A3=14.0'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/gauss_noisy-fb.txt
+++ b/examples/benchmark_problems/simple_tests/gauss_noisy-fb.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we fit a curve to a noisy Gaussian.
+description = 'This is a simple test problem where we fit a curve to a noisy Gaussian.'
 software = 'Mantid'
 name = 'gauss-noisy-fb'
 input_file = 'gauss-noisy.txt'
 function = 'name=UserFunction, Formula=A1*exp( -( (A2-x)^2 / (2* (A3^2) ) ) ), A1=0.0, A2=0.0, A3=1.0'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/gauss_noisy-fba.txt
+++ b/examples/benchmark_problems/simple_tests/gauss_noisy-fba.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we fit a curve to a noisy Gaussian.
+description = 'This is a simple test problem where we fit a curve to a noisy Gaussian.'
 software = 'Mantid'
 name = 'gauss-noisy-fba'
 input_file = 'gauss-noisy.txt'
 function = 'name=UserFunction, Formula=A1*exp( -( (A2-x)^2 / (2* (A3^2) ) ) ), A1=1.01, A2=3.98, A3=3.01'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/trig_exact-fb.txt
+++ b/examples/benchmark_problems/simple_tests/trig_exact-fb.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we interpolate points that lie exactly on a trigonometric function.
+description = 'This is a simple test problem where we interpolate points that lie exactly on a trigonometric function.'
 software = 'Mantid'
 name = 'trig_exact-fb'
 input_file = 'trig_exact.txt'
 function = 'name=UserFunction, Formula=A1*cos(2*3.14159265359*x) + A2*sin(2*3.14159653592*x) + A3*x, A1=0.0, A2=0.0, A3=0.0'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/trig_exact-fba.txt
+++ b/examples/benchmark_problems/simple_tests/trig_exact-fba.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we interpolate points the lie exactly on a trigonometric function.
+description = 'This is a simple test problem where we interpolate points the lie exactly on a trigonometric function.'
 software = 'Mantid'
 name = 'trig_exact-fba'
 input_file = 'trig_exact.txt'
 function = 'name=UserFunction, Formula=A1*cos(2*3.14159265359*x) + A2*sin(2*3.14159653592*x) + A3*x, A1=1.01, A2=3.98, A3=3.01'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/trig_noisy-fb.txt
+++ b/examples/benchmark_problems/simple_tests/trig_noisy-fb.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we create noisy data from a trigonometric function.
+description = 'This is a simple test problem where we create noisy data from a trigonometric function.'
 software = 'Mantid'
 name = 'trig_noisy-fb'
 input_file = 'trig_noisy.txt'
 function = 'name=UserFunction, Formula=A1*cos(2*3.141592*x) + A2*sin(2*3.141592*x) + A3*x, A1=0.0, A2=0.0, A3=0.0'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/examples/benchmark_problems/simple_tests/trig_noisy-fba.txt
+++ b/examples/benchmark_problems/simple_tests/trig_noisy-fba.txt
@@ -1,8 +1,7 @@
 # FitBenchmark Problem
-# This is a simple test problem where we create noisy data from a trigonometric function.
+description = 'This is a simple test problem where we create noisy data from a trigonometric function.'
 software = 'Mantid'
 name = 'trig_noisy-fba'
 input_file = 'trig_noisy.txt'
 function = 'name=UserFunction, Formula=A1*cos(2*3.141592*x) + A2*sin(2*3.141592*x) + A3*x, A1=1.01, A2=3.98, A3=3.01'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''

--- a/fitbenchmarking/mock_problems/all_parsers_set/trig_noisy-fba.txt
+++ b/fitbenchmarking/mock_problems/all_parsers_set/trig_noisy-fba.txt
@@ -1,8 +1,8 @@
 # FitBenchmark Problem
-# This is a simple test problem where we create noisy data from a trigonometric function.
+description = 'This is a simple test problem where we create noisy data from a trigonometric function.'
 software = 'Mantid'
 name = 'trig_noisy-fba'
 input_file = 'trig_noisy.txt'
 function = 'name=UserFunction, Formula=A1*cos(2*3.141592*x) + A2*sin(2*3.141592*x) + A3*x, A1=1.01, A2=3.98, A3=3.01'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''
+

--- a/fitbenchmarking/mock_problems/cubic-fba-test-bounds.txt
+++ b/fitbenchmarking/mock_problems/cubic-fba-test-bounds.txt
@@ -1,9 +1,8 @@
 # FitBenchmark Problem
-# This is a simple test problem where we interpolate points that lie exactly on a cubic polynomial.
 software = 'mantid'
 name = 'cubic-fba'
+description = 'This is a simple test problem where we interpolate points that lie exactly on a cubic polynomial.'
 input_file = 'cubic.txt'
 function ='name=UserFunction, Formula=A1+A2*x+A3*x^2+A4*x^3, A1=8, A2=2.98, A3=4, A4=1.02'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''
 parameter_ranges = {'A1': (6,10)}

--- a/fitbenchmarking/mock_problems/cubic-fba-test-go.txt
+++ b/fitbenchmarking/mock_problems/cubic-fba-test-go.txt
@@ -1,9 +1,8 @@
 # FitBenchmark Problem
-# This is a simple test problem where we interpolate points that lie exactly on a cubic polynomial.
 software = 'mantid'
 name = 'cubic-fba'
+description = 'This is a simple test problem where we interpolate points that lie exactly on a cubic polynomial.'
 input_file = 'cubic.txt'
 function ='name=UserFunction, Formula=A1+A2*x+A3*x^2+A4*x^3, A1=8, A2=2.98, A3=4, A4=1.02'
 # fit_parameters = {'StartX': 0, 'EndX': 0}
-description = ''
 parameter_ranges = {'A1': (6,10), 'A2': (1,5), 'A3': (1,6), 'A4': (1,3)}

--- a/fitbenchmarking/parsing/fitbenchmark_parser.py
+++ b/fitbenchmarking/parsing/fitbenchmark_parser.py
@@ -43,13 +43,11 @@ class FitbenchmarkParser(Parser):
 
         self.fitting_problem.multifit = self._is_multifit()
 
-        # NAME
         self.fitting_problem.name = self._entries['name']
+        self.fitting_problem.description = self._entries['description']
 
-        # DATA
         data_points = [_get_data_points(p) for p in self._get_data_file()]
 
-        # FUNCTION
         self.fitting_problem.function = self._create_function()
         self.fitting_problem.format = self._entries['software'].lower()
 

--- a/fitbenchmarking/results_processing/fitting_report.py
+++ b/fitbenchmarking/results_processing/fitting_report.py
@@ -80,6 +80,7 @@ def create_prob_group(result, support_pages_dir, options):
             table_style=css['table'],
             custom_style=css['custom'],
             title=result.name,
+            description=result.problem.description,
             equation=result.problem.equation,
             initial_guess=result.ini_function_params,
             minimizer=result.minimizer,

--- a/fitbenchmarking/templates/fitting_report_template.html
+++ b/fitbenchmarking/templates/fitting_report_template.html
@@ -16,64 +16,80 @@
                     <hr>
                 </div>
                 <p>{{ description }}</p>
-                <h2>Problem Outline</h2>
-                <p><em>Functions</em>:</p>
-                <table>
-                    <colgroup>
-                    <col width="45%" />
-                    <col width="55%" />
-                    </colgroup>
-                    <thead valign="bottom">
-                        <tr>
-                            <th class="head">Form</th>
+                <hr>
+                <section class="accordion">
+                    <input type="checkbox" name="collapse" id="start-accordion" checked="checked">
+                    <h2 class="handle">
+                        <label for="start-accordion">Problem Outline</label>
+                    </h2>
+                    <div class="content">
+                        <p><em>Functions</em>:</p>
+                        <table>
+                            <colgroup>
+                                <col width="45%" />
+                                <col width="55%" />
+                            </colgroup>
+                            <thead valign="bottom">
+                                <tr>
+                                    <th class="head">Form</th>
+                                    <th class="head">Parameters</th>
+                                </tr>
+                            </thead>
+                            <tbody valign="top">
+                                <tr>
+                                    <td>{{ equation }}</td>
+                                    <td>{{ initial_guess }}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <div class="row">
+                            {% if initial_plot_available %}
+                                <img alt="{{ initial_plot }}" src="{{ initial_plot }}" />
+                            {% else %}
+                                <h3>{{ initial_plot }}</h3>
+                            {% endif %}
+                        </div>
+                    </div>
+                </section>
+            <section class="accordion">
+                <input type="checkbox" name="collapse" id="fitting-results-accordion" checked="checked">
+                <h2 class="handle">
+                    <label for="fitting-results-accordion">Fitting Results</label>
+                </h2>
+                <div class="content">
+                    {% if is_best_fit %}
+                        <p><b>This is the best fit of the minimizers used.</b></p>
+                    {% endif %}
+                    <p><em>Minimizer</em>: {{ minimizer }}</p>
+                    <p><em>Functions</em>:</p>
+                    <table>
+                        <colgroup>
+                            <col width="36%" />
+                            <col width="64%" />
+                        </colgroup>
+                        <thead valign="bottom">
+                            <tr><th class="head">Form</th>
                             <th class="head">Parameters</th>
-                        </tr>
-                    </thead>
-                    <tbody valign="top">
-                        <tr><td>{{ equation }}</td>
-                        <td>{{ initial_guess }}</td>
-                    </tr>
-                </tbody>
-            </table>
-            <div class="row">
-                {% if initial_plot_available %}
-                    <img alt="{{ initial_plot }}" src="{{ initial_plot }}" />
-                {% else %}
-                    <h3>{{ initial_plot }}</h3>
-                {% endif %}
-            </div>
-            <h2>Fitting Results</h2>
-            {% if is_best_fit %}
-                <b>This is the best fit of the minimizers used.</b>
-            {% endif %}
-            <p><em>Minimizer</em>: {{ minimizer }}</p>
-            <p><em>Functions</em>:</p>
-            <table>
-                <colgroup>
-                <col width="36%" />
-                <col width="64%" />
-                </colgroup>
-                <thead valign="bottom">
-                    <tr><th class="head">Form</th>
-                    <th class="head">Parameters</th>
-                </thead>
-                <tbody valign="top">
-                    <tr>
-                        <td>{{ equation }}</td>
-                        <td>{{ min_params }}</td>
-                    </tr>
-                </tbody>
-            </table>
-            <div align="center" class="figure align-center">
-                {% if fitted_plot_available %}
-                    <img alt="{{ fitted_plot }}" src="{{ fitted_plot }}" />
-                {% else %}
-                    <h3>{{ fitted_plot }}</h3>
-                {% endif %}
-                <button class="btn default" onclick="history.go(-1)">
-                <i class="fa fa-arrow-left"></i>
-                </button>
-            </div>
+                        </thead>
+                        <tbody valign="top">
+                            <tr>
+                                <td>{{ equation }}</td>
+                                <td>{{ min_params }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <div align="center" class="figure align-center">
+                        {% if fitted_plot_available %}
+                            <img alt="{{ fitted_plot }}" src="{{ fitted_plot }}" />
+                        {% else %}
+                            <h3>{{ fitted_plot }}</h3>
+                        {% endif %}
+                        <button class="btn default" onclick="history.go(-1)">
+                        <i class="fa fa-arrow-left"></i>
+                        </button>
+                    </div>
+                </div>
+            </section>
         </div>
     </body>
 </html>

--- a/fitbenchmarking/templates/fitting_report_template.html
+++ b/fitbenchmarking/templates/fitting_report_template.html
@@ -15,6 +15,7 @@
                     <h1>{{ title }}</h1>
                     <hr>
                 </div>
+                <p>{{ description }}</p>
                 <h2>Problem Outline</h2>
                 <p><em>Functions</em>:</p>
                 <table>


### PR DESCRIPTION
#### Description of Work
This PR makes sure the problem descriptions are loaded for NIST, Mantid, SASView and IVP problem files. There doesn't seem to be a description option for `CUTEst` format in here so its been left out:
https://github.com/jfowkes/pycutest/blob/15794b214756f0cd54cde9e453304abc2eb8d42b/pycutest/problem_class.py#L41

I have also made the sections in the Fitting reports collapsible just like they are in the problem summary pages.

Fixes #948 

#### Testing Instructions

1. Run a benchmark of a mantid, NIST, SASView and IVP problem. Look at a comparison table and click the problem name - there should be a description at the top of the page that is open.
2. There should be no change to CUTEst
3. Check that the Fitting Reports have a problem description and that each section is collapsible

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
