### PR TITLE
Pin mistune to `0.8.4`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 m2r2
+mistune==0.8.4
 sphinx~=4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 m2r2
-mistune==0.8.4
+mistune==0.8.4 # This is a dependency of m2r2 causing an error after bumping from 0.8.4 to 2.0.0
 sphinx~=4.0


### PR DESCRIPTION
#### Description of Work
This PR fixes a docs failure described in this issue https://github.com/CrossNox/m2r2/issues/40 by pinning mistune to 0.8.4.

### To test
Check that the docs pass, and that pinning mistune is sensible.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
