### PR TITLE
Add links from the tables to the cost function docs

### DIFF
--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -306,13 +306,20 @@ class Table:
         table = self.create_pandas_data_frame(html=True)
 
         # Format the table headers
-        cost_func_template = '<span class="cost_function_header">{0}</span>'
+        cost_func_template = '<a class="cost_function_header" ' \
+                             'href=https://fitbenchmarking.readthedocs.io/' \
+                             'en/latest/users/options/fitting_option.html' \
+                             '#cost-function-cost-func-type ' \
+                             'target="_blank">{0}</a>'
         software_template = '<a class="software_header" ' \
                             'href="https://fitbenchmarking.readthedocs.io/' \
                             'en/latest/users/options/minimizer_option.html' \
                             '#{0}" target="_blank">{0}</a>'
-        minimizer_template = '<span class="minimizer_header" col={0} ' \
-                             'title="{1}">{2}</span>'
+        minimizer_template = '<a class="minimizer_header" col={0} ' \
+                             'title="{1}"' \
+                             'href="https://fitbenchmarking.readthedocs.io/' \
+                             'en/latest/users/options/minimizer_option.html' \
+                             '#{2}" target="_blank">{3}</a>'
 
         row = next(iter(self.sorted_results.values()))
         minimizers_list = [
@@ -320,6 +327,7 @@ class Table:
              software_template.format(result.software.replace('_', '-')),
              minimizer_template.format(
                  i, self.options.minimizer_alg_type[result.minimizer],
+                 result.software.replace('_', '-'),
                  result.minimizer))
             for i, result in enumerate(row)]
         columns = pd.MultiIndex.from_tuples(minimizers_list)

--- a/fitbenchmarking/results_processing/tests/expected_results/acc.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/acc.html
@@ -19,7 +19,7 @@
   <thead>
     <tr>
       <th class="blank level0" >&nbsp;</th>
-      <th class="col_heading level0 col0" colspan="3"><span class="cost_function_header">WeightedNLLSCostFunc</span></th>
+      <th class="col_heading level0 col0" colspan="3"><a class="cost_function_header" href=https://fitbenchmarking.readthedocs.io/en/latest/users/options/fitting_option.html#cost-function-cost-func-type target="_blank">WeightedNLLSCostFunc</a></th>
     </tr>
     <tr>
       <th class="blank level1" >&nbsp;</th>
@@ -27,9 +27,9 @@
     </tr>
     <tr>
       <th class="blank level2" >&nbsp;</th>
-      <th class="col_heading level2 col0" ><span class="minimizer_header" col=0 title="all, ls">dogbox</span></th>
-      <th class="col_heading level2 col1" ><span class="minimizer_header" col=1 title="all, ls">lm-scipy</span></th>
-      <th class="col_heading level2 col2" ><span class="minimizer_header" col=2 title="all, ls">trf</span></th>
+      <th class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">dogbox</a></th>
+      <th class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">lm-scipy</a></th>
+      <th class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">trf</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/compare.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/compare.html
@@ -22,7 +22,7 @@
   <thead>
     <tr>
       <th class="blank level0" >&nbsp;</th>
-      <th class="col_heading level0 col0" colspan="3"><span class="cost_function_header">WeightedNLLSCostFunc</span></th>
+      <th class="col_heading level0 col0" colspan="3"><a class="cost_function_header" href=https://fitbenchmarking.readthedocs.io/en/latest/users/options/fitting_option.html#cost-function-cost-func-type target="_blank">WeightedNLLSCostFunc</a></th>
     </tr>
     <tr>
       <th class="blank level1" >&nbsp;</th>
@@ -30,9 +30,9 @@
     </tr>
     <tr>
       <th class="blank level2" >&nbsp;</th>
-      <th class="col_heading level2 col0" ><span class="minimizer_header" col=0 title="all, ls">dogbox</span></th>
-      <th class="col_heading level2 col1" ><span class="minimizer_header" col=1 title="all, ls">lm-scipy</span></th>
-      <th class="col_heading level2 col2" ><span class="minimizer_header" col=2 title="all, ls">trf</span></th>
+      <th class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">dogbox</a></th>
+      <th class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">lm-scipy</a></th>
+      <th class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">trf</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/local_min.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/local_min.html
@@ -7,7 +7,7 @@
   <thead>
     <tr>
       <th class="blank level0" >&nbsp;</th>
-      <th class="col_heading level0 col0" colspan="3"><span class="cost_function_header">WeightedNLLSCostFunc</span></th>
+      <th class="col_heading level0 col0" colspan="3"><a class="cost_function_header" href=https://fitbenchmarking.readthedocs.io/en/latest/users/options/fitting_option.html#cost-function-cost-func-type target="_blank">WeightedNLLSCostFunc</a></th>
     </tr>
     <tr>
       <th class="blank level1" >&nbsp;</th>
@@ -15,9 +15,9 @@
     </tr>
     <tr>
       <th class="blank level2" >&nbsp;</th>
-      <th class="col_heading level2 col0" ><span class="minimizer_header" col=0 title="all, ls">dogbox</span></th>
-      <th class="col_heading level2 col1" ><span class="minimizer_header" col=1 title="all, ls">lm-scipy</span></th>
-      <th class="col_heading level2 col2" ><span class="minimizer_header" col=2 title="all, ls">trf</span></th>
+      <th class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">dogbox</a></th>
+      <th class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">lm-scipy</a></th>
+      <th class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">trf</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/runtime.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/runtime.html
@@ -13,7 +13,7 @@
   <thead>
     <tr>
       <th class="blank level0" >&nbsp;</th>
-      <th class="col_heading level0 col0" colspan="3"><span class="cost_function_header">WeightedNLLSCostFunc</span></th>
+      <th class="col_heading level0 col0" colspan="3"><a class="cost_function_header" href=https://fitbenchmarking.readthedocs.io/en/latest/users/options/fitting_option.html#cost-function-cost-func-type target="_blank">WeightedNLLSCostFunc</a></th>
     </tr>
     <tr>
       <th class="blank level1" >&nbsp;</th>
@@ -21,9 +21,9 @@
     </tr>
     <tr>
       <th class="blank level2" >&nbsp;</th>
-      <th class="col_heading level2 col0" ><span class="minimizer_header" col=0 title="all, ls">dogbox</span></th>
-      <th class="col_heading level2 col1" ><span class="minimizer_header" col=1 title="all, ls">lm-scipy</span></th>
-      <th class="col_heading level2 col2" ><span class="minimizer_header" col=2 title="all, ls">trf</span></th>
+      <th class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">dogbox</a></th>
+      <th class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">lm-scipy</a></th>
+      <th class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="all, ls"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#scipy-ls" target="_blank">trf</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/templates/js/table.js
+++ b/fitbenchmarking/templates/js/table.js
@@ -45,9 +45,9 @@ function toggle_problem(problem_name) {
 * @param   {String} minimizer  The name of the minimizer as it appears in the table column header.
 */
 function toggle_minimizer(software, minimizer) {
-    var cost_function_header = $("span.cost_function_header").parent();
+    var cost_function_header = $("a.cost_function_header").parent();
     var software_header = _find_element_from_text("a.software_header", software).parent();
-    var minimizer_text = _find_element_from_text("span.minimizer_header", minimizer);
+    var minimizer_text = _find_element_from_text("a.minimizer_header", minimizer);
     var minimizer_header = minimizer_text.parent();
 
     // Toggle the minimizer header


### PR DESCRIPTION
#### Description of Work
This PR adds links to the generated tables when clicking on the cost function or minimizer names.

Fixes #999


#### Testing Instructions

1. Do a benchmark and click on the name of a cost function or minimizer in one of the generated table. Make sure they link to the appropriate documentation page

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
