### PR TITLE
Fix bullet points not appearing in documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 m2r2
 mistune==0.8.4 # This is a dependency of m2r2 causing an error after bumping from 0.8.4 to 2.0.0
+sphinx-rtd-theme==1.0.0 # This fixes the missing bullet points in the documentation
 sphinx~=4.0

--- a/docs/source/users/options/logging_option.rst
+++ b/docs/source/users/options/logging_option.rst
@@ -61,8 +61,7 @@ Logging external output (:code:`external_output`)
 This selects the amount of information displayed from third-parties.
 There are 3 options:
 
-* ``display``: Print information from third-parties to the stdout stream
-               during a run.
+* ``display``: Print information from third-parties to the stdout stream during a run.
 * ``log_only``: Print information to the log file but not the stdout stream.
 * ``debug``: Do not intercept third-party use of output streams.
 


### PR DESCRIPTION
#### Description of Work
This PR fixes two issues. The first is to do with the bullet points missing in the documentation, and is fixed making sure `sphinx-rtd-theme==1.0.0` gets installed. The second issue was caused by some unintended indentation.

Credit to @AndrewLister-STFC for finding the problem with the first issue.

Fixes #1005 #1006


#### Testing Instructions

1. Build the docs and make sure the two attached issues are now fixed.

Function: Does the change do what it's supposed to?

Tests: Does it pass? Is there adequate coverage for new code?

Style: Is the coding style consistent? Is anything overly confusing?

Documentation: Is there a suitable change to documentation for this change?
