### PR TITLE
Enable max runtime in curve fitting

### DIFF
--- a/fitbenchmarking/controllers/horace_controller.py
+++ b/fitbenchmarking/controllers/horace_controller.py
@@ -87,3 +87,9 @@ class HoraceController(MatlabMixin, Controller):
             self.flag = 0
 
         self.final_params = self._fit_params['p'][0]
+
+        # Allow repeat calls to cleanup without falling over
+        try:
+            self.eng.evalc('horace_off')
+        except matlab.engine.MatlabExecutionError:
+            pass

--- a/fitbenchmarking/controllers/horace_controller.py
+++ b/fitbenchmarking/controllers/horace_controller.py
@@ -61,11 +61,8 @@ class HoraceController(MatlabMixin, Controller):
 
         # serialize cost_func.eval_r and open within matlab engine
         # so that matlab fitting function can be called
-        self.eng.workspace['eval_f'] = self.py_to_mat(self.cost_func.eval_r)
+        self.eng.workspace['eval_f'] = self.py_to_mat('eval_r')
         self.eng.evalc('f_wrapper = @(x, p) double(eval_f(p))')
-
-        # Setup the timer to track using calls to eval_f
-        self.setup_timer('eval_f')
 
         # Setup multifit data structures
         self.eng.evalc('kk = multifit(W)')

--- a/fitbenchmarking/controllers/matlab_controller.py
+++ b/fitbenchmarking/controllers/matlab_controller.py
@@ -50,11 +50,7 @@ class MatlabController(MatlabMixin, Controller):
 
         # serialize cost_func.eval_cost and open within matlab engine
         # so that matlab fitting function can be called
-        self.eng.workspace['eval_cost_mat'] =\
-            self.py_to_mat(self.cost_func.eval_cost)
-
-        # Setup the timer to track using calls to eval_cost_mat
-        self.setup_timer('eval_cost_mat')
+        self.eng.workspace['eval_cost_mat'] = self.py_to_mat('eval_cost')
 
     def fit(self):
         """

--- a/fitbenchmarking/controllers/matlab_curve_controller.py
+++ b/fitbenchmarking/controllers/matlab_curve_controller.py
@@ -2,8 +2,6 @@
 Implements a controller for MATLAB Curve Fitting Toolbox
 """
 import os
-from tempfile import TemporaryDirectory
-
 import matlab
 
 from fitbenchmarking.controllers.base_controller import Controller
@@ -46,7 +44,6 @@ class MatlabCurveController(MatlabMixin, Controller):
         self.options = None
         self._status = None
         self.result = None
-        self.tempdir = TemporaryDirectory()
 
     def setup(self):
         """

--- a/fitbenchmarking/controllers/matlab_curve_controller.py
+++ b/fitbenchmarking/controllers/matlab_curve_controller.py
@@ -63,26 +63,9 @@ class MatlabCurveController(MatlabMixin, Controller):
         else:
             self.eng.workspace['e_data'] = matlab.double([])
 
-        eval_r_path = os.path.join(self.tempdir.name, 'eval_r.m')
-        with open(eval_r_path, 'w', encoding='utf-8') as f:
-            f.write(
-                "function out=eval_r(x, y, varargin)                     \n"
-                "    global data_e;                                      \n"
-                "    global cf;                                          \n"
-                "    if length(data_e) == length(y)                      \n"
-                "        e = data_e;                                     \n"
-                "    else                                                \n"
-                "        e = ones(size(y));                              \n"
-                "    end                                                 \n"
-                "    p = py.list(cell2mat(varargin));                    \n"
-                "    x = py.numpy.array(x);                              \n"
-                "    y = py.numpy.array(y);                              \n"
-                "    e = py.numpy.array(e);                              \n"
-                "    out = cf.eval_r(p, pyargs('x', x, 'y', y, 'e', e)); \n"
-                "end                                                     \n"
-            )
-
-        self.eng.addpath(self.tempdir.name)
+        eval_path = os.path.join(os.path.dirname(__file__),
+                                 'matlab_curve_controller')
+        self.eng.addpath(eval_path)
 
         if self.value_ranges is not None:
             lb, ub = zip(*self.value_ranges)

--- a/fitbenchmarking/controllers/matlab_curve_controller/eval_r.m
+++ b/fitbenchmarking/controllers/matlab_curve_controller/eval_r.m
@@ -1,0 +1,13 @@
+function out=eval_r(x, y, varargin)
+    global data_e;
+    global cf;
+    p = py.list(cell2mat(varargin));
+    if length(data_e) == length(y)
+        out = cf.eval_r(p);
+    else
+        x = py.numpy.array(x);
+        y = py.numpy.array(y);
+        e = py.numpy.ones_like(y);
+        out = cf.eval_r(p, pyargs('x', x, 'y', y, 'e', e));
+    end
+end

--- a/fitbenchmarking/controllers/matlab_mixin.py
+++ b/fitbenchmarking/controllers/matlab_mixin.py
@@ -19,7 +19,7 @@ try:
     eng = matlab.engine.connect_matlab(name='FITBENCHMARKING_MATLAB')
 except matlab.engine.EngineError:
     eng = matlab.engine.start_matlab()
-    eng.shareEngine('FITBENCHMARKING_MATLAB')
+    eng.matlab.engine.shareEngine('FITBENCHMARKING_MATLAB', nargout=0)
 
 
 # If we re-implement caching, make sure the cache is cleared by the

--- a/fitbenchmarking/controllers/matlab_mixin.py
+++ b/fitbenchmarking/controllers/matlab_mixin.py
@@ -15,7 +15,11 @@ try:
 except ImportError:
     import_success = False
 
-eng = matlab.engine.start_matlab()
+try:
+    eng = matlab.engine.connect_matlab(name='FITBENCHMARKING_MATLAB')
+except matlab.engine.EngineError:
+    eng = matlab.engine.start_matlab()
+    eng.shareEngine('FITBENCHMARKING_MATLAB')
 
 
 # If we re-implement caching, make sure the cache is cleared by the

--- a/fitbenchmarking/controllers/matlab_mixin.py
+++ b/fitbenchmarking/controllers/matlab_mixin.py
@@ -84,7 +84,8 @@ class MatlabMixin:
         :param func: The name of the function to retrieve
         :type func: str
         """
-        return self.eng.evalc(f'py.getattr(cf, "{func}")')
+        self.eng.evalc(f'fct = py.getattr(cf, "{func}");')
+        return self.eng.workspace['fct']
 
 
 class MatlabTimerInterface:

--- a/fitbenchmarking/controllers/matlab_mixin.py
+++ b/fitbenchmarking/controllers/matlab_mixin.py
@@ -7,7 +7,8 @@ from tempfile import TemporaryDirectory
 
 import matlab.engine
 
-from fitbenchmarking.utils.exceptions import IncompatibleProblemError, MissingSoftwareError
+from fitbenchmarking.utils.exceptions import (IncompatibleProblemError,
+                                              MissingSoftwareError)
 
 try:
     import dill

--- a/fitbenchmarking/controllers/matlab_mixin.py
+++ b/fitbenchmarking/controllers/matlab_mixin.py
@@ -30,8 +30,6 @@ class MatlabMixin:
     Mixin class for matlab fitting software controllers
     """
 
-    incompatible_problems = ['mantid']
-
     def __init__(self, cost_func):
         """
         Initialise anything that is needed specifically for matlab

--- a/fitbenchmarking/controllers/matlab_mixin.py
+++ b/fitbenchmarking/controllers/matlab_mixin.py
@@ -75,9 +75,7 @@ class MatlabMixin:
         """
         self.eng.clear('variables', nargout=0)
         self.eng.evalc('global cf')
-        if self.original_timer is not None:
-            self.timer = self.original_timer
-            self.original_timer = None
+        self.eng.evalc('global timer')
 
     def setup_timer(self):
         """
@@ -89,6 +87,7 @@ class MatlabMixin:
         This overrides the controller's timer so that it can be controlled from
         other parts of the code.
         """
+        self.eng.evalc('global timer')
         self.eng.evalc('timer = cf.problem.timer')
         if self.original_timer is None:
             self.original_timer = self.timer

--- a/fitbenchmarking/controllers/matlab_opt_controller.py
+++ b/fitbenchmarking/controllers/matlab_opt_controller.py
@@ -74,11 +74,8 @@ class MatlabOptController(MatlabMixin, Controller):
         # serialize cost_func.eval_r and jacobian.eval (if not
         # using default jacobian) and open within matlab engine
         # so matlab fitting function can be called
-        self.eng.workspace['eval_f'] = self.py_to_mat(self.cost_func.eval_r)
+        self.eng.workspace['eval_f'] = self.py_to_mat('eval_r')
         self.eng.evalc('f_wrapper = @(p, x)double(eval_f(p));')
-
-        # Setup the timer to track using calls to eval_f
-        self.setup_timer('eval_f')
 
         self.eng.workspace['init'] = self.initial_params_mat
         self.eng.workspace['x'] = self.x_data_mat
@@ -86,8 +83,7 @@ class MatlabOptController(MatlabMixin, Controller):
         # if default jacobian is not selected then pass _jeval
         # function to matlab
         if not self.cost_func.jacobian.use_default_jac:
-            self.eng.workspace['eval_j'] = self.py_to_mat(
-                self.cost_func.jac_res)
+            self.eng.workspace['eval_j'] = self.py_to_mat('jac_res')
             self.eng.evalc('j_wrapper = @(p, x)double(eval_j(p));')
 
             self.eng.workspace['eval_func'] = [self.eng.workspace['f_wrapper'],

--- a/fitbenchmarking/controllers/matlab_stats_controller.py
+++ b/fitbenchmarking/controllers/matlab_stats_controller.py
@@ -57,11 +57,8 @@ class MatlabStatsController(MatlabMixin, Controller):
 
         # serialize cost_func.eval_r and open within matlab engine
         # so that matlab fitting function can be called
-        self.eng.workspace['eval_f'] = self.py_to_mat(self.cost_func.eval_r)
+        self.eng.workspace['eval_f'] = self.py_to_mat('eval_r')
         self.eng.evalc('f_wrapper = @(p, x)double(eval_f(p))')
-
-        # Setup the timer to track using calls to eval_f
-        self.setup_timer('eval_f')
 
     def fit(self):
         """

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -105,7 +105,7 @@ class ControllerSharedTesting:
         """
         controller.parameter_set = 0
         controller.prepare()
-        controller.fit()
+        controller.execute()
         controller.cleanup()
 
         assert len(controller.final_params) == len(controller.initial_params)
@@ -922,7 +922,7 @@ class MatlabControllerTests(TestCase):
 
         result_py = self.cost_func.eval_cost(params=params)
         result_mat = eng.eval('test_mat_func([1, 2, 3, 4])')
-
+        controller.clear_matlab()
         assert result_py == result_mat
 
     def test_verify(self):
@@ -940,6 +940,7 @@ class MatlabControllerTests(TestCase):
         controller = MatlabController(cost_func)
         with self.assertRaises(exceptions.IncompatibleProblemError):
             controller.validate()
+        controller.clear_matlab()
 
     def test_matlab(self):
         """
@@ -958,6 +959,7 @@ class MatlabControllerTests(TestCase):
             self.shared_tests.check_max_iterations(controller)
             controller._status = -1
             self.shared_tests.check_diverged(controller)
+            controller.clear_matlab()
 
     def test_matlab_opt(self):
         """
@@ -976,6 +978,7 @@ class MatlabControllerTests(TestCase):
             self.shared_tests.check_max_iterations(controller)
             controller._status = -1
             self.shared_tests.check_diverged(controller)
+            controller.clear_matlab()
 
     def test_matlab_stats(self):
         """
@@ -992,6 +995,7 @@ class MatlabControllerTests(TestCase):
             self.shared_tests.check_converged(controller)
             controller._status = 1
             self.shared_tests.check_diverged(controller)
+            controller.clear_matlab()
 
     def test_matlab_curve(self):
         """
@@ -1010,6 +1014,7 @@ class MatlabControllerTests(TestCase):
             self.shared_tests.check_max_iterations(controller)
             controller._status = -1
             self.shared_tests.check_diverged(controller)
+            controller.clear_matlab()
 
     def test_horace(self):
         """
@@ -1026,6 +1031,7 @@ class MatlabControllerTests(TestCase):
             self.shared_tests.check_converged(controller)
             controller._fit_params['converged'] = 0
             self.shared_tests.check_diverged(controller)
+            controller.clear_matlab()
 
 
 @run_for_test_types(TEST_TYPE, 'all')

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -894,7 +894,7 @@ class ExternalControllerTests(TestCase):
 @run_for_test_types(TEST_TYPE, 'matlab')
 class MatlabControllerTests(TestCase):
     """
-    Tests for each controller classb and for the
+    Tests for each controller class and for the
     Base Matlab Controller
     """
 
@@ -916,7 +916,7 @@ class MatlabControllerTests(TestCase):
         controller = MatlabController(self.cost_func)
         eng = controller.eng
         eng.workspace['test_mat_func'] =\
-            controller.py_to_mat(self.cost_func.eval_cost)
+            controller.py_to_mat('eval_cost')
 
         params = np.array([1, 2, 3, 4])
 


### PR DESCRIPTION
#### Description of Work

Fixes matlab curve fitting toolbox with max runtime

Replaces the wrapper with one written in matlab. This is written to a temp file and saved for matlab to open. The cost function and default data are passed via global variables... which might be unwise but I thought it was ok in this very bizare situation.

A side effect of this chang is that the serialisation of all matlab controllers will now be done for the cost function. With individual methods on the cost function being accessed from the same object. This should be an improvement as we currently have multiple instances of the exact (hopefully) same object when both the residual and jacobian are passed into matlab.

TODO:
 - Incorporate changes from #1034 as this will be a clash


#### Testing Instructions

1. Try running with matlab controller and max runtime.
2. Run the matlab tests

Function: Does the change do what it's supposed to?
Tests: Does it pass? Is there adequate coverage for new code?
Style: Is the coding style consistent? Is anything overly confusing?
Documentation: Is there a suitable change to documentation for this change?
