### PR TITLE
Pass fitting_link as absolute path internally

### DIFF
--- a/fitbenchmarking/core/results_output.py
+++ b/fitbenchmarking/core/results_output.py
@@ -456,13 +456,21 @@ def open_browser(output_file: str, options) -> None:
     :param output_file: The absolute path to the results index file.
     :type output_file: str
     """
-    # Uses the relative path so that the browser can open on Mac and WSL
-    relative_path = os.path.relpath(output_file)
-    # Constructs a url that can be pasted into a browser
-    is_mac = platform.system() == "Darwin"
-    url = "file://" + output_file if is_mac else output_file
+    use_url = False
+    # On Mac, need prefix for webbrowser
+    if platform.system() == 'Darwin':
+        url = "file://" + output_file
+        use_url = True
+    else:
+        url = output_file
+    # On windows can have drive clashes so need to use absolute path
+    if platform.system() == 'Windows':
+        use_url = True
+
     if options.results_browser:
-        if webbrowser.open_new(url if is_mac else relative_path):
+        # Uses the relative path so that the browser can open on WSL
+        to_open = url if use_url else os.path.relpath(output_file)
+        if webbrowser.open_new(to_open):
             LOGGER.info("\nINFO:\nThe FitBenchmarking results have been opened"
                         " in your browser from this url:\n\n   %s", url)
         else:
@@ -471,4 +479,5 @@ def open_browser(output_file: str, options) -> None:
                            "into your browser:\n\n   %s", url)
     else:
         LOGGER.info("\nINFO:\nYou have chosen not to open FitBenchmarking "
-                    "results in your browser\n\n   %s",)
+                    "results in your browser. You can use this link to see the"
+                    "results: \n\n   %s", url)

--- a/fitbenchmarking/results_processing/fitting_report.py
+++ b/fitbenchmarking/results_processing/fitting_report.py
@@ -95,7 +95,7 @@ def create_prob_group(result, support_pages_dir, options):
             fitted_plot_available=fit_success,
             fitted_plot=fig_fit))
 
-    result.fitting_report_link = os.path.relpath(file_path)
+    result.fitting_report_link = os.path.abspath(file_path)
 
 
 def get_figure_paths(result):

--- a/fitbenchmarking/results_processing/tests/test_fitting_report.py
+++ b/fitbenchmarking/results_processing/tests/test_fitting_report.py
@@ -93,8 +93,8 @@ class CreateProbGroupTests(unittest.TestCase):
                                          support_pages_dir=self.dir.name,
                                          options=self.options)
         file_name = self.result.fitting_report_link
-        expected = os.path.join(os.path.relpath(self.dir.name),
-                                'prob_0_cf1_m10_[s1]_jj0.html')
+        expected = os.path.abspath(
+            os.path.join(self.dir.name, 'prob_0_cf1_m10_[s1]_jj0.html'))
 
         self.assertEqual(file_name, expected)
 


### PR DESCRIPTION
#### Description of Work

Fixes #1149 

Convert path to absolute path before passing around, convert back to relative before displaying.
Display in webbrowser using abs path on windows

#### Testing Instructions

1. Is the windows test passing?

Function: Does the change do what it's supposed to?
Tests: Does it pass? Is there adequate coverage for new code?
Style: Is the coding style consistent? Is anything overly confusing?
Documentation: Is there a suitable change to documentation for this change?
