### PR TITLE
Fix issues with scipy hessian and mantid jacobian

### DIFF
--- a/fitbenchmarking/hessian/numdifftools_hessian.py
+++ b/fitbenchmarking/hessian/numdifftools_hessian.py
@@ -1,6 +1,8 @@
 """
 Module which calculates numdifftools finite difference approximations
 """
+from functools import lru_cache
+
 import numdifftools as nd
 
 from fitbenchmarking.hessian.base_hessian import Hessian
@@ -25,8 +27,13 @@ class Numdifftools(Hessian):
         """
         x = kwargs.get("x", self.problem.data_x)
 
-        def jac_func(params):
+        @lru_cache
+        def grad(params):
             return self.jacobian.eval(params, x=x).T
+
+        def jac_func(params):
+            return grad(tuple(params))
+
         hes_func = nd.Jacobian(jac_func, method=self.method)
         hes = hes_func(params)
 


### PR DESCRIPTION
## Description of work

While testing the #1231 PR, I found that it failed with the Scipy hessian.
This updates the scipy hessian to only evaluate on the whole x domain (so that the mantid jacobian can be calculated efficiently). A cache is used to allow only the minimum jacobian evaluations needed.

@AnthonyLim23 let me know if you're happy with these changes? I didn't want to change your PR without your feedback!

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1.
2.
3.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [ ] The title is of a format appropriate for a line in future release notes.
- [ ] I have added the appropriate tags to the PR.
- [ ] My PR represents one logical piece of work.
- [ ] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [ ] I have added the appropriate tests to cover code that has been added.
- [ ] I have updated the documentation in the relevant places to cover the changes.

