### PR TITLE
Updated bumps and lmfit controllers to be more robust against parameter names

### DIFF
--- a/fitbenchmarking/controllers/bumps_controller.py
+++ b/fitbenchmarking/controllers/bumps_controller.py
@@ -49,7 +49,8 @@ class BumpsController(Controller):
         """
         super().__init__(cost_func)
         # Need unique strings that are valid python vars
-        self._param_names = [f'p{i}' for (i, _) in self.problem.param_names]
+        self._param_names = [
+            f'p{i}' for (i, _) in enumerate(self.problem.param_names)]
         self.support_for_bounds = True
         self._func_wrapper = None
         self._fit_problem = None

--- a/fitbenchmarking/controllers/bumps_controller.py
+++ b/fitbenchmarking/controllers/bumps_controller.py
@@ -2,10 +2,9 @@
 Implements a controller for the Bumps fitting software.
 """
 
+import numpy as np
 from bumps.fitters import fit as bumpsFit
 from bumps.names import Curve, FitProblem, PoissonCurve
-
-import numpy as np
 
 from fitbenchmarking.controllers.base_controller import Controller
 from fitbenchmarking.cost_func.cost_func_factory import create_cost_func
@@ -21,24 +20,24 @@ class BumpsController(Controller):
     """
 
     algorithm_check = {
-            'all': ['amoeba',
-                    'lm-bumps',
-                    'newton',
-                    'de',
-                    'scipy-leastsq',
-                    'dream'],
-            'ls': ['lm-bumps', 'scipy-leastsq'],
-            'deriv_free': ['amoeba', 'de'],
-            'general': ['amoeba', 'newton', 'de'],
-            'simplex': ['amoeba'],
-            'trust_region': ['lm-bumps', 'scipy-leastsq'],
-            'levenberg-marquardt': ['lm-bumps', 'scipy-leastsq'],
-            'gauss_newton': [],
-            'bfgs': ['newton'],
-            'conjugate_gradient': [],
-            'steepest_descent': [],
-            'global_optimization': ['de'],
-            'MCMC': ['dream']}
+        'all': ['amoeba',
+                'lm-bumps',
+                'newton',
+                'de',
+                'scipy-leastsq',
+                'dream'],
+        'ls': ['lm-bumps', 'scipy-leastsq'],
+        'deriv_free': ['amoeba', 'de'],
+        'general': ['amoeba', 'newton', 'de'],
+        'simplex': ['amoeba'],
+        'trust_region': ['lm-bumps', 'scipy-leastsq'],
+        'levenberg-marquardt': ['lm-bumps', 'scipy-leastsq'],
+        'gauss_newton': [],
+        'bfgs': ['newton'],
+        'conjugate_gradient': [],
+        'steepest_descent': [],
+        'global_optimization': ['de'],
+        'MCMC': ['dream']}
 
     def __init__(self, cost_func):
         """
@@ -49,9 +48,8 @@ class BumpsController(Controller):
                 :class:`~fitbenchmarking.cost_func.base_cost_func.CostFunc`
         """
         super().__init__(cost_func)
-
-        self._param_names = [name.replace('.', '_')
-                             for name in self.problem.param_names]
+        # Need unique strings that are valid python vars
+        self._param_names = [f'p{i}' for (i, _) in self.problem.param_names]
         self.support_for_bounds = True
         self._func_wrapper = None
         self._fit_problem = None

--- a/fitbenchmarking/controllers/lmfit_controller.py
+++ b/fitbenchmarking/controllers/lmfit_controller.py
@@ -105,13 +105,15 @@ class LmfitController(Controller):
         self.bound_minimizers = ['dual_annealing', 'differential_evolution']
         self.lmfit_out = None
         self.lmfit_params = Parameters()
+        self._param_names = [
+            f'p{i}' for (i, _) in enumerate(self.problem.param_names)]
 
     def lmfit_resdiuals(self, params):
         """
         lmfit resdiuals
         """
         return self.cost_func.eval_r(list(map(lambda name: params[name].value,
-                                     self.problem.param_names)))
+                                     self._param_names)))
 
     def lmfit_jacobians(self, params):
         """
@@ -119,7 +121,7 @@ class LmfitController(Controller):
         """
         return self.cost_func.jac_cost(list(map(lambda name:
                                        params[name].value,
-                                       self.problem.param_names)))
+                                       self._param_names)))
 
     def setup(self):
         """
@@ -132,7 +134,7 @@ class LmfitController(Controller):
                     f"{self.minimizer} requires finite bounds on all"
                     " parameters")
 
-        for i, name in enumerate(self.problem.param_names):
+        for i, name in enumerate(self._param_names):
             kwargs = {"name": name,
                       "value": self.initial_params[i]}
             if self.value_ranges is not None:

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -523,6 +523,16 @@ class DefaultControllerTests(TestCase):
         controller.lmfit_out.success = False
         self.shared_tests.check_diverged(controller)
 
+    def test_variable_names_corrected_in_controllers(self):
+        """
+        Test if variable names are corrected properly
+        within the LmfitController and BumpsController
+        """
+        for control in ([LmfitController, BumpsController]):
+            self.cost_func.param_names = ['b.1', 'b@2', 'b-3', 'b_4']
+            controller = control(self.cost_func)
+            assert controller._param_names == ['p0', 'p1', 'p2', 'p3']
+
 
 @run_for_test_types(TEST_TYPE, 'all')
 class ControllerBoundsTests(TestCase):


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1247 

<!---

Describe your changes and why you're making them.

-->
Assign numerical parameter names to variables within the context of the bumps controller.
These are only used in a mapping that has to be generated via the use of `eval` as bumps does not allow for **arg expansion.


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1.
2.
3.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [ ] The title is of a format appropriate for a line in future release notes.
- [ ] I have added the appropriate tags to the PR.
- [ ] My PR represents one logical piece of work.
- [ ] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [ ] I have added the appropriate tests to cover code that has been added.
- [ ] I have updated the documentation in the relevant places to cover the changes.

