### PR TITLE
Updated relative runtime calculation in FittingResult

### DIFF
--- a/fitbenchmarking/utils/fitbm_result.py
+++ b/fitbenchmarking/utils/fitbm_result.py
@@ -356,7 +356,7 @@ class FittingResult:
         """
         Stores the normalised accuracy and updates the value
 
-        :param value: New value for norm_runtime
+        :param value: New value for norm_accuracy
         :type value: float
         """
         self._norm_acc = value
@@ -373,7 +373,7 @@ class FittingResult:
             if self.min_runtime in [np.nan, np.inf]:
                 self._norm_runtime = np.inf
             else:
-                self._norm_runtime = self.mean_runtime / self.min_runtime
+                self._norm_runtime = self.runtime / self.min_runtime
         return self._norm_runtime
 
     @norm_runtime.setter

--- a/fitbenchmarking/utils/tests/test_fitbm_result.py
+++ b/fitbenchmarking/utils/tests/test_fitbm_result.py
@@ -180,9 +180,8 @@ class FitbmResultTests(unittest.TestCase):
         """
         Tests the runtime metrics calculations within FittingResults
         """
-        controller = self.controller
         result = FittingResult(
-            controller=controller,
+            controller=self.controller,
             runtimes=runtimes,
             runtime_metric=metric)
         self.assertAlmostEqual(expected,
@@ -222,9 +221,8 @@ class FitbmResultTests(unittest.TestCase):
         """
         Test that norm_runtime is correct when min_runtime is finite.
         """
-        controller = self.controller
         result = FittingResult(
-            controller=controller,
+            controller=self.controller,
             runtimes=runtimes,
             runtime_metric=metric)
         result.min_runtime = min_runtime

--- a/fitbenchmarking/utils/tests/test_fitbm_result.py
+++ b/fitbenchmarking/utils/tests/test_fitbm_result.py
@@ -9,6 +9,7 @@ import unittest
 from typing import TYPE_CHECKING
 
 import numpy as np
+from parameterized import parameterized
 
 from fitbenchmarking import test_files
 from fitbenchmarking.controllers.scipy_controller import ScipyController
@@ -156,138 +157,82 @@ class FitbmResultTests(unittest.TestCase):
             np.isclose(controller.final_params[1], result.params).all())
         self.assertEqual(chi_sq[1], result.accuracy)
 
-    def test_runtime_metrics(self):
+    @parameterized.expand([
+        ('mean', [0.005, 0.015, 0.01], 0.01),
+        ('mean', [1.00, 2.00, 3.00], 2.0),
+        ('mean', [3.00], 3.0),
+        ('mean', [np.inf, 2.00, 3.00], np.inf),
+        ('mean', [np.inf, np.inf, np.inf], np.inf),
+        ('minimum', [1.00, 2.00, 3.00, 4.00, 6.00], 1.00),
+        ('minimum', [0, 2.00, 3.00, 4.00, 6.00], 0),
+        ('maximum', [0, 2.00, 3.00, 4.00, 6.00], 6.00),
+        ('maximum', [0], 0),
+        ('first', [40, 100, 10], 40),
+        ('median', [0, 3.00, 2.00, 4.00, 6.00], 3.0),
+        ('median', [0, 2.00, 3.00, 4.00, 6.00, 10.0], 3.5),
+        ('harmonic', [2.00, 5.00, 4.00, 6.00], 3.58209),
+        ('harmonic', [2.00, 5.00, 4.00, 6.00, 10.0, 20.0], 4.73684),
+        ('harmonic', [0, 5.00, 4.00, 6.00, 10.0, 20.0], 0),
+        ('trim', [0, 5.00, 4.00, 6.00, 10.0, 20.0], 6.25),
+        ('trim', [1.0, 4.00, 6.00, 10.0, 20.0, 40], 10),
+    ])
+    def test_runtime_metrics(self, metric, runtimes, expected):
         """
         Tests the runtime metrics calculations within FittingResults
         """
-        testcases = [{
-                        'metric': 'mean',
-                        'runtimes':  [0.005, 0.015, 0.01],
-                        'expected':  0.01,
-                     },
-                     {
-                        'metric': 'mean',
-                        'runtimes':  [1.00, 2.00, 3.00],
-                        'expected':  2.0,
-                     },
-                     {
-                        'metric': 'mean',
-                        'runtimes':  [3.00],
-                        'expected':  3.0,
-                     },
-                     {
-                        'metric': 'mean',
-                        'runtimes':  [np.inf, 2.00, 3.00],
-                        'expected':  np.inf,
-                     },
-                     {
-                        'metric': 'mean',
-                        'runtimes':  [np.inf, np.inf, np.inf],
-                        'expected':  np.inf,
-                     },
-                     {
-                        'metric': 'minimum',
-                        'runtimes':  [1.00, 2.00, 3.00, 4.00, 6.00],
-                        'expected':  1.00,
-                     },
-                     {
-                        'metric': 'minimum',
-                        'runtimes':  [0, 2.00, 3.00, 4.00, 6.00],
-                        'expected':  0,
-                     },
-                     {
-                        'metric': 'maximum',
-                        'runtimes':  [0, 2.00, 3.00, 4.00, 6.00],
-                        'expected':  6.00,
-                     },
-                     {
-                        'metric': 'maximum',
-                        'runtimes':  [0],
-                        'expected':  0,
-                     },
-                     {
-                        'metric': 'first',
-                        'runtimes':  [0],
-                        'expected':  0,
-                     },
-                     {
-                        'metric': 'first',
-                        'runtimes':  [40, 100, 10],
-                        'expected':  40,
-                     },
-                     {
-                        'metric': 'median',
-                        'runtimes':  [0, 3.00, 2.00, 4.00, 6.00],
-                        'expected':  3.0,
-                     },
-                     {
-                        'metric': 'median',
-                        'runtimes':  [0, 2.00, 3.00, 4.00, 6.00, 10.0],
-                        'expected':  3.5,
-                     },
-                     {
-                        'metric': 'harmonic',
-                        'runtimes':  [2.00, 5.00, 4.00, 6.00],
-                        'expected':  3.58209,
-                     },
-                     {
-                        'metric': 'harmonic',
-                        'runtimes':  [2.00, 5.00, 4.00, 6.00, 10.0, 20.0],
-                        'expected':  4.73684,
-                     },
-                     {
-                        'metric': 'harmonic',
-                        'runtimes':  [0, 5.00, 4.00, 6.00, 10.0, 20.0],
-                        'expected':  0,
-                     },
-                     {
-                        'metric': 'trim',
-                        'runtimes':  [0, 5.00, 4.00, 6.00, 10.0, 20.0],
-                        'expected':  6.25,
-                     },
-                     {
-                        'metric': 'trim',
-                        'runtimes':  [1.0, 4.00, 6.00, 10.0, 20.0, 40],
-                        'expected':  10,
-                     }]
-
-        for case in testcases:
-            with self.subTest(case['runtimes']):
-                controller = self.controller
-                result = FittingResult(
-                    controller=controller,
-                    runtimes=case['runtimes'],
-                    runtime_metric=case['metric'])
-                self.assertAlmostEqual(case['expected'],
-                                       result.runtime,
-                                       places=5)
+        controller = self.controller
+        result = FittingResult(
+            controller=controller,
+            runtimes=runtimes,
+            runtime_metric=metric)
+        self.assertAlmostEqual(expected,
+                               result.runtime,
+                               places=5)
 
     def test_norm_acc_finite_min(self):
         """
-        Test that sanitised names are correct when min_acc is finite.
+        Test that norm_acc is correct when min_acc is finite.
         """
         expected = self.accuracy / self.min_accuracy
         self.assertEqual(self.result.norm_acc, expected)
 
     def test_norm_acc_infinite_min(self):
         """
-        Test that sanitised names are correct when min_acc is infinite.
+        Test that norm_acc is correct when min_acc is infinite.
         """
         expected = np.inf
         self.result.accuracy = np.inf
         self.result.min_accuracy = np.inf
         self.assertEqual(self.result.norm_acc, expected)
 
-    def test_norm_runtime_finite_min(self):
+    @parameterized.expand([
+        ('mean', [0.005, 0.015, 0.01], 0.001, 10),
+        ('minimum', [1.00, 2.00, 3.00, 4.00, 6.00], 0.05, 20),
+        ('maximum', [0, 2.00, 3.00, 4.00, 6.00], 3.00, 2),
+        ('first', [40, 100, 10], 10, 4),
+        ('median', [0, 2.00, 3.00, 4.00, 6.00, 10.0], 0.5, 7),
+        ('harmonic', [2.00, 5.00, 4.00, 6.00, 10.0, 20.0], 4.73684, 1),
+        ('trim', [0, 5.00, 4.00, 6.00, 10.0, 20.0], 0.25, 25),
+    ])
+    def test_norm_runtime_finite_min(self,
+                                     metric,
+                                     runtimes,
+                                     min_runtime,
+                                     expected):
         """
-        Test that sanitised names are correct when min_runtime is finite.
+        Test that norm_runtime is correct when min_runtime is finite.
         """
-        expected = self.runtime / self.min_runtime
-        self.assertEqual(self.result.norm_runtime, expected)
+        controller = self.controller
+        result = FittingResult(
+            controller=controller,
+            runtimes=runtimes,
+            runtime_metric=metric)
+        result.min_runtime = min_runtime
+        self.assertAlmostEqual(expected, result.norm_runtime, places=5)
 
     def test_norm_runtime_infinite_min(self):
         """
-        Test that sanitised names are correct when min_runtime is infinite.
+        Test that norm_runtime is correct when min_runtime is infinite.
         """
         expected = np.inf
         self.result.runtime = np.inf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
     'pandas',
     'iminuit>=2.25.2',
     'pre-commit',
+    'parameterized',
 ]
 
 [project.scripts]


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1220 

Updates the relative runtime calculation in `FittingResult`

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Run `fitbenchmarking -rt trim` to verify relative values are based on the selected metric.
2. Run `pytest fitbenchmarking/utils/tests/test_fitbm_result.py --test-type default` to verify all tests pass.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

