### PR TITLE
Fixed emissions display when not measured

### DIFF
--- a/examples/options_template.ini
+++ b/examples/options_template.ini
@@ -26,11 +26,6 @@ make_plots: no
 
 results_dir: new_results/
 
-table_type: acc
-            runtime
-            compare
-            local_min
-
 [LOGGING]
 
 external_output: log_only

--- a/fitbenchmarking/results_processing/fitting_report.py
+++ b/fitbenchmarking/results_processing/fitting_report.py
@@ -86,7 +86,7 @@ def create_prob_group(result, support_pages_dir, options):
     else:
         emission_disp = f"{result.emissions:.4g} kg CO\u2082 eq"
 
-    with open(file_path, 'w') as fh:
+    with open(file_path, 'w', encoding='utf-8') as fh:
         fh.write(template.render(
             css_style_sheet=css['main'],
             table_style=css['table'],

--- a/fitbenchmarking/results_processing/fitting_report.py
+++ b/fitbenchmarking/results_processing/fitting_report.py
@@ -7,7 +7,6 @@ import inspect
 import os
 
 import numpy as np
-
 from jinja2 import Environment, FileSystemLoader
 
 import fitbenchmarking
@@ -82,6 +81,11 @@ def create_prob_group(result, support_pages_dir, options):
     css = get_css(options, support_pages_dir)
     template = env.get_template("fitting_report_template.html")
 
+    if np.isnan(result.emissions):
+        emission_disp = 'N/A'
+    else:
+        emission_disp = f"{result.emissions:.4g} kg CO\u2082 eq"
+
     with open(file_path, 'w') as fh:
         fh.write(template.render(
             css_style_sheet=css['main'],
@@ -95,7 +99,7 @@ def create_prob_group(result, support_pages_dir, options):
             minimizer=result.modified_minimizer_name(),
             accuracy=f"{result.accuracy:.4g}",
             runtime=f"{result.runtime:.4g}",
-            emissions=f"{result.emissions:.4g}",
+            emissions=emission_disp,
             is_best_fit=result.is_best_fit,
             initial_plot_available=init_success,
             initial_plot=fig_start,

--- a/fitbenchmarking/templates/fitting_report_template.html
+++ b/fitbenchmarking/templates/fitting_report_template.html
@@ -65,7 +65,7 @@
                     <p><em>Minimizer</em>: {{ minimizer }}</p>
                     <p><em>Accuracy</em>: {{ accuracy }}</p>
                     <p><em>Runtime</em>: {{ runtime }} seconds</p>
-                    <p><em>Emissions</em>: {{ emissions }} kg CO<sub>2</sub>eq</p>
+                    <p><em>Emissions</em>: {{ emissions }}</p>
                     <p><em>Functions</em>:</p>
                     <table>
                         <colgroup>


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1221 

Changes fitting report so that Emissions value is listed as 'N/A' when the emissions table option is not selected. I have also updated the `options_template.ini` so that the emissions table is not deactivated, as measuring emissions is no longer painfully slow.

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Run Fitbenchmarking without emissions table option, and check fitting report.
2. 
3.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

