### PR TITLE
Removed codecarbon hack for avoiding div by zero

### DIFF
--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -7,8 +7,6 @@ fitting software.
 """
 
 import os
-import platform
-import time
 import timeit
 
 import numpy as np
@@ -72,16 +70,6 @@ class Fit:
         self.__logger_prefix = "    "
         if 'emissions' in options.table_type:
             self.__emissions_tracker = EmissionsTracker()
-            if platform.system() == 'Windows':
-                # Temporary hack to artificially create a delay to avoid
-                # div by zero
-                hs = self.__emissions_tracker._hardware[0].start
-
-                def new_hs(*args, **kwargs):
-                    time.sleep(1e-10)
-                    return hs(*args, **kwargs)
-
-                self.__emissions_tracker._hardware[0].start = new_hs
 
     def benchmark(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     'pandas>=1.3',
     'jinja2',
     'configparser',
-    'codecarbon>=2.3.4',
+    'codecarbon>=2.5.1',
     'dash',
 ]
 


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

CodeCarbon v2.5.1 includes a fix for the [divide by zero error in `start_task()`](https://github.com/mlco2/codecarbon/issues/549), so the hack put in place to get around this in [this PR](https://github.com/fitbenchmarking/fitbenchmarking/pull/1285) can now be removed.

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Run FitBenchmarking on Windows with emissions table selected and check that emissions results are produced
2.
3.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

