### PR TITLE
Fix issue where failures were incorrectly reported in performance profile

### DIFF
--- a/fitbenchmarking/results_processing/performance_profiler.py
+++ b/fitbenchmarking/results_processing/performance_profiler.py
@@ -277,13 +277,11 @@ def adjust_values_to_plot(step_values: 'list[np.ndarray]',
         label = f"{solver}"
         plot_points = np.linspace(0.0, 1.0, solver_values.size)
         plot_points = np.append(plot_points, 1.0)
-        inf_indices = np.where(solver_values > huge)
-        solver_values[inf_indices] = huge
-        if inf_indices[0].size > 0:
-            plural_ending = "s"
-            if inf_indices[0].size == 1:
-                plural_ending = ""
-            label = f"{solver} ({len(inf_indices[0])} failure{plural_ending})"
+        failures = np.isinf(solver_values).sum()
+        huge_indices = np.where(solver_values > huge)
+        solver_values[huge_indices] = huge
+        if failures > 0:
+            label += f" ({failures} failure{'s' if failures > 1 else ''})"
         solver_values = np.append(solver_values, huge)
 
         all_labels.append(label)
@@ -342,10 +340,10 @@ def create_plot(step_values: 'list[np.ndarray]',
     avail_styles = compute_linestyle_combinations()
 
     for label, solver_values, plot_points in zip(
-                                                data_to_plot['labels'],
-                                                data_to_plot['solver_values'],
-                                                data_to_plot['plot_points']
-                                                ):
+        data_to_plot['labels'],
+        data_to_plot['solver_values'],
+        data_to_plot['plot_points']
+    ):
 
         linestyle, colour = avail_styles.pop()
 
@@ -359,7 +357,7 @@ def create_plot(step_values: 'list[np.ndarray]',
                        name=label,
                        type='scatter'
                        )
-            )
+        )
 
     return fig
 

--- a/fitbenchmarking/results_processing/tests/test_performance_profiler.py
+++ b/fitbenchmarking/results_processing/tests/test_performance_profiler.py
@@ -348,6 +348,38 @@ class PerformanceProfilerTests(unittest.TestCase):
         assert np.array_equal(expected_dict['plot_points'],
                               output_dict['plot_points'])
 
+    def test_adjust_values_to_plot_failures(self):
+        """
+        Test adjust_values_to_plot when failures are present.
+        """
+        solvers = ["Solver1", "Solver2", "Solver3"]
+        step_vals = [
+            np.array([0.0, 0.0123, 0.123, 1.23, 8.2]),
+            np.array([0.0, 0.12, 1e23, np.inf, np.inf]),
+            np.array([0.0, 3.8, 5.6, 1e29, np.inf]),
+        ]
+
+        labels = ["Solver1", "Solver2 (2 failures)", "Solver3 (1 failure)"]
+        solver_vals = [
+            np.array([0.0, 0.0123, 0.123, 1.23, 8.2, 1e20]),
+            np.array([0.0, 0.12, 1e20, 1e20, 1e20, 1e20]),
+            np.array([0.0, 3.8, 5.6, 1e20, 1e20, 1e20]),
+        ]
+        plot_points = [
+            np.array([0.0, 0.25, 0.5, 0.75, 1.0, 1.0]),
+            np.array([0.0, 0.25, 0.5, 0.75, 1.0, 1.0]),
+            np.array([0.0, 0.25, 0.5, 0.75, 1.0, 1.0]),
+        ]
+
+        res = performance_profiler.adjust_values_to_plot(
+            step_values=step_vals, solvers=solvers
+        )
+
+        assert res["solvers"] == solvers
+        assert res["labels"] == labels
+        assert np.array_equal(res["solver_values"], solver_vals)
+        assert np.array_equal(res["plot_points"], plot_points)
+
     def test_compute_linestyle_combinations(self):
         """
         Test compute_linestyle_combinations returns expected styles.


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1240

<!---

Describe your changes and why you're making them.

-->

Counts failures as an `np.inf` rather than `> 1e20`.


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Run the test example from the comment in the issue and verify no failures
2. Run it with gradient_free as well and verify all fail correctly (gradient free requires bounds)

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [ ] ~I have updated the documentation in the relevant places to cover the changes.~
- [x] I don't think this requires any doc changes