### PR TITLE
Fix issue where perf profiles could be out of sync in dash

### DIFF
--- a/fitbenchmarking/core/results_output.py
+++ b/fitbenchmarking/core/results_output.py
@@ -588,8 +588,12 @@ def check_max_solvers(opts, solvers, max_solvers):
     return opts
 
 
-def display_page(pathname, profile_instances_all_groups,
-                 layout, max_solvers):
+def display_page(
+    pathname: str,
+    profile_instances_all_groups: "dict[str, dict[str, DashPerfProfile]]",
+    layout: "list",
+    max_solvers: int
+):
     """
     Update the layout of the dash app.
 
@@ -621,7 +625,18 @@ def display_page(pathname, profile_instances_all_groups,
     new_layout = layout
 
     try:
+        first_metric = True
+        current_styles = {}
+        avail_styles = []
         for metric in metric_str.split('+'):
+            if first_metric:
+                current_styles = group_profiles[metric].current_styles
+                avail_styles = group_profiles[metric].avail_styles
+                first_metric = False
+            else:
+                group_profiles[metric].current_styles = current_styles
+                group_profiles[metric].avail_styles = avail_styles
+
             new_layout = new_layout + [group_profiles[metric].layout()]
     except KeyError:
         return ("404 Page Error! The path was not recognized. \n"

--- a/fitbenchmarking/core/tests/test_results_output.py
+++ b/fitbenchmarking/core/tests/test_results_output.py
@@ -22,11 +22,8 @@ from fitbenchmarking.core.results_output import (_extract_tags,
                                                  create_directories,
                                                  create_plots,
                                                  create_problem_level_index,
-                                                 display_page,
-                                                 preprocess_data,
-                                                 save_results,
-                                                 update_warning)
-
+                                                 display_page, preprocess_data,
+                                                 save_results, update_warning)
 from fitbenchmarking.results_processing.performance_profiler import \
     DashPerfProfile
 from fitbenchmarking.utils.checkpoint import Checkpoint
@@ -674,6 +671,33 @@ class DisplayPageTests(unittest.TestCase):
                         'visual NIST_low_difficulty-Accuracy',
                         'visual NIST_low_difficulty-Runtime']
         self.assertEqual(output_ids, expected_ids)
+
+    def test_styles_consistent_when_two_plts(self):
+        """
+        Test that the styles of lines on the graphs are consistent when
+        pathname refers to two plots.
+        """
+        pathname = "127.0.0.1:5009/NIST_low_difficulty/pp/acc+runtime"
+        pps = self.profile_instances_all_groups["NIST_low_difficulty"]
+        pp = pps["acc"]
+        pp.current_styles["solver1"] = pp.avail_styles.pop()
+
+        _ = display_page(
+            pathname,
+            self.profile_instances_all_groups,
+            self.layout,
+            self.max_solvers
+        )
+
+        self.assertDictEqual(
+            pps["acc"].current_styles,
+            pps["runtime"].current_styles
+        )
+
+        self.assertListEqual(
+            pps["acc"].avail_styles,
+            pps["runtime"].avail_styles
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1256 

<!---

Describe your changes and why you're making them.

-->
Copies the formatting from the first plot chosen when multiple are displayed via dash.

## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Go to accuracy table page and click online plots (while dash is running)
2. Remove all lines and add them back in a random order so the colours are different
3. Check against the online plots on the runtime table page to make sure they disagree
4. Open the compare table and check that they update to match

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

