### PR TITLE
Added error message for online plots that are unavailable

### DIFF
--- a/fitbenchmarking/core/results_output.py
+++ b/fitbenchmarking/core/results_output.py
@@ -589,7 +589,7 @@ def check_max_solvers(opts, solvers, max_solvers):
 
 
 def display_page(pathname, profile_instances_all_groups,
-                 layout, max_solvers):
+                 layout, max_solvers, run_id):
     """
     Update the layout of the dash app.
 
@@ -601,18 +601,25 @@ def display_page(pathname, profile_instances_all_groups,
     :type layout: list of dcc or html components
     :param max_solvers: Maximum number of solvers that can be plotted
     :type max_solvers: int
+    :param run_id: The id for the run that is plotted in dash
+    :type run_id: str
 
     :return: The updated layout
     :rtype: html.Div
     """
 
     try:
-        _, group, plot, metric_str = pathname.split('/')
+        _, plot_id, group, plot, metric_str = pathname.split('/')
     except ValueError:
         return ("404 Page Error! Path does not have the expected shape. "
                 "Please provide it in the following form:  \n"
-                "ip-address:port/problem_set/plot/performance_profile.")
+                "ip-address:port/run_id/problem_set/plot/performance_profile.")
 
+    if run_id != plot_id:
+        return (
+            "404 Page Error! Dash plots are not available for these results."
+            "You can use `fitbenchmarking --load-checkpoint` to fix this."
+        )
     if plot != "pp":
         return f"404 Page Error! Plot type '{plot}' not available."
 
@@ -729,7 +736,9 @@ def run_dash_app(options, pp_dfs_all_prob_sets) -> None:
                 x,
                 profile_instances_all_groups=profile_instances_all_groups,
                 layout=layout,
-                max_solvers=max_solvers)
+                max_solvers=max_solvers,
+                run_id=options.run_id,
+            )
     )
 
     app.run(port=options.port)

--- a/fitbenchmarking/core/results_output.py
+++ b/fitbenchmarking/core/results_output.py
@@ -611,7 +611,7 @@ def display_page(pathname, profile_instances_all_groups,
     try:
         _, plot_id, group, plot, metric_str = pathname.split('/')
     except ValueError:
-        return ("404 Page Error! Path does not have the expected shape. "
+        return ("404 Page Error! Path does not have the expected format. "
                 "Please provide it in the following form:  \n"
                 "ip-address:port/run_id/problem_set/plot/performance_profile.")
 

--- a/fitbenchmarking/core/tests/test_results_output.py
+++ b/fitbenchmarking/core/tests/test_results_output.py
@@ -22,11 +22,8 @@ from fitbenchmarking.core.results_output import (_extract_tags,
                                                  create_directories,
                                                  create_plots,
                                                  create_problem_level_index,
-                                                 display_page,
-                                                 preprocess_data,
-                                                 save_results,
-                                                 update_warning)
-
+                                                 display_page, preprocess_data,
+                                                 save_results, update_warning)
 from fitbenchmarking.results_processing.performance_profiler import \
     DashPerfProfile
 from fitbenchmarking.utils.checkpoint import Checkpoint
@@ -649,11 +646,13 @@ class DisplayPageTests(unittest.TestCase):
         Test that the expected layout components are returned when the
         pathname refers to one plot only.
         """
-        pathname = "127.0.0.1:5009/NIST_low_difficulty/pp/acc"
-        output_div = display_page(pathname,
-                                  self.profile_instances_all_groups,
-                                  self.layout,
-                                  self.max_solvers)
+        pathname = "127.0.0.1:5009/abc/NIST_low_difficulty/pp/acc"
+        output_div = display_page(
+            pathname=pathname,
+            profile_instances_all_groups=self.profile_instances_all_groups,
+            layout=self.layout,
+            max_solvers=self.max_solvers,
+            run_id="abc")
         output_ids = list(output_div)
         expected_ids = ['Log axis toggle', 'dropdown', 'warning',
                         'visual NIST_low_difficulty-Accuracy']
@@ -664,16 +663,71 @@ class DisplayPageTests(unittest.TestCase):
         Test that the expected layout components are returned when the
         pathname refers to two plots.
         """
-        pathname = "127.0.0.1:5009/NIST_low_difficulty/pp/acc+runtime"
-        output_div = display_page(pathname,
-                                  self.profile_instances_all_groups,
-                                  self.layout,
-                                  self.max_solvers)
+        pathname = "127.0.0.1:5009/123/NIST_low_difficulty/pp/acc+runtime"
+        output_div = display_page(
+            pathname=pathname,
+            profile_instances_all_groups=self.profile_instances_all_groups,
+            layout=self.layout,
+            max_solvers=self.max_solvers,
+            run_id="123",
+        )
         output_ids = list(output_div)
         expected_ids = ['Log axis toggle', 'dropdown', 'warning',
                         'visual NIST_low_difficulty-Accuracy',
                         'visual NIST_low_difficulty-Runtime']
         self.assertEqual(output_ids, expected_ids)
+
+    def test_wrong_id(self):
+        """
+        Tests that an error is produced when the id is incorrect.
+        """
+        pathname = "127.0.0.1:5009/old_id/NIST_low_difficulty/pp/acc+runtime"
+        run_id = "new_id"
+
+        output_div = display_page(
+            pathname=pathname,
+            profile_instances_all_groups=self.profile_instances_all_groups,
+            layout=self.layout,
+            max_solvers=self.max_solvers,
+            run_id=run_id,
+        )
+        assert (
+            isinstance(output_div, str) and output_div.startswith("404")
+        ), f"No error reported for {pathname=}, {run_id=}"
+
+    def test_wrong_plot_type(self):
+        """
+        Tests that an error is produced when the plot type is incorrect.
+        """
+        pathname = "127.0.0.1:5009/abc/NIST_low_difficulty/??/acc+runtime"
+
+        output_div = display_page(
+            pathname=pathname,
+            profile_instances_all_groups=self.profile_instances_all_groups,
+            layout=self.layout,
+            max_solvers=self.max_solvers,
+            run_id="abc",
+        )
+        assert (
+            isinstance(output_div, str) and output_div.startswith("404")
+        ), f"No error reported for {pathname=}, ?? is not a plot type"
+
+    def test_wrong_path_format(self):
+        """
+        Tests that an error is produced when the pathname has the wrong format.
+        """
+        pathname = "127.0.0.1:5009/abc/pp/acc+runtime"
+
+        output_div = display_page(
+            pathname=pathname,
+            profile_instances_all_groups=self.profile_instances_all_groups,
+            layout=self.layout,
+            max_solvers=self.max_solvers,
+            run_id="abc",
+        )
+        assert (
+            isinstance(output_div, str) and output_div.startswith("404")
+        ), f"No error reported for {pathname=}, missing group_name"
 
 
 if __name__ == "__main__":

--- a/fitbenchmarking/results_processing/tables.py
+++ b/fitbenchmarking/results_processing/tables.py
@@ -140,6 +140,7 @@ def create_results_tables(options, results, best_results, group_dir, fig_dir,
                             os.path.relpath(table.pp_locations[p], group_dir)
                             for p in table.pps],
                         pp_dash_url=f'http://127.0.0.1:{options.port}/'
+                                    f"{options.run_id}/"
                                     f'{os.path.basename(group_dir)}/'
                                     f'pp/{"+".join(table.pps)}',
                         cbar=cbar,

--- a/fitbenchmarking/utils/options.py
+++ b/fitbenchmarking/utils/options.py
@@ -6,6 +6,7 @@ This file will handle all interaction with the options configuration file.
 import configparser
 import glob
 import os
+import uuid
 
 import matplotlib.pyplot as plt
 
@@ -346,6 +347,8 @@ class Options:
         :type additional_options: dict
 
         """
+        self.run_id = uuid.uuid4().hex
+
         # additional_options is initialied to an empty dict if
         # no value is given
         if additional_options is None:

--- a/fitbenchmarking/utils/tests/test_options_generic.py
+++ b/fitbenchmarking/utils/tests/test_options_generic.py
@@ -80,6 +80,10 @@ class OptionsWriteTests(unittest.TestCase):
         options.stored_file_name = ""
         new_options.stored_file_name = ""
 
+        # Overwrite run_id
+        options.run_id = ""
+        new_options.run_id = ""
+
         self.assertDictEqual(options.__dict__, new_options.__dict__)
 
     def test_write_to_stream(self):
@@ -100,6 +104,10 @@ class OptionsWriteTests(unittest.TestCase):
         # Overwrite file names
         options.stored_file_name = ""
         new_options.stored_file_name = ""
+
+        # Overwrite run_id
+        options.run_id = ""
+        new_options.run_id = ""
 
         os.remove(new_file_name)
         self.assertDictEqual(options.__dict__, new_options.__dict__)


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1253 

<!---

Describe your changes and why you're making them.

-->
Options now creates a uuid for every instance, and this is embedded in the dash urls.
If the uuid of the options file does not match the dash url, a message about using `--load-checkpoint` is displayed.

Existing plots will get an error saying the url is in the wrong format.

## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Try to recreate the issue as explained in my comment

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

