### PR TITLE
Fix issues for sas and mantid on container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Install dependencies
       run: |
+        sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install pybind11[global]
         sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install .[bumps,DFO,gofit,minuit,SAS,numdifftools,lmfit,nlopt,paramonte]
         sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install --upgrade .[dev]
     - name: Run tests
@@ -50,6 +51,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Install dependencies
       run: |
+        sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install pybind11[global]
         sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install .[bumps,DFO,gofit,levmar,minuit,SAS,numdifftools,lmfit,nlopt,paramonte,hogben]
         sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install --upgrade .[dev]
         mkdir -p $MASTSIF
@@ -77,6 +79,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Install dependencies
       run: |
+        sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install pybind11[global]
         sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install .[bumps,DFO,gofit,gradient-free,levmar,minuit,SAS,numdifftools,lmfit,nlopt,paramonte,hogben]
         sudo -HE --preserve-env=PATH $VIRTUAL_ENV/bin/pip install --upgrade .[dev]
         mkdir -p $MASTSIF

--- a/Container/Containerfile
+++ b/Container/Containerfile
@@ -27,9 +27,10 @@ RUN pip install "pytest>3.6" \
     pytest-cov \
     coveralls \
     "coverage~=4.5.4" \ 
-    "urllib3==1.23" \
+    urllib3 \
     mock \
-    meson 
+    meson \
+    "numpy<2.0"
 
 WORKDIR /
 
@@ -108,6 +109,8 @@ WORKDIR $CUTEST
 RUN meson setup builddir
 RUN meson compile -C builddir
 RUN meson install -C builddir
+RUN ln -s /usr/local/libcutest_single.a object/pc64.lnx.gfo/single/libcutest.a
+RUN ln -s /usr/local/libcutest_double.a object/pc64.lnx.gfo/double/libcutest.a
 
 # install pycutest
 RUN python -m pip install pycutest
@@ -146,7 +149,7 @@ RUN cmake -G Ninja /mantid-$MANTID_VERSION -DENABLE_MANTIDQT=OFF -DENABLE_WORKBE
 RUN cmake --build .
 
 ENV PYTHONPATH=$PYTHONPATH:/opt/Mantid/lib:/opt/Mantid/bin
-RUN python -m pip install IPython six python-dateutil pyyaml h5py
+RUN python -m pip install --no-binary=h5py IPython six python-dateutil pyyaml h5py
 ENV HDF5_DISABLE_VERSION_CHECK=2
 RUN /opt/Mantid/bin/mantidpython -m  mantid.simpleapi || echo "expected segfault on first run"
 

--- a/Container/Containerfile
+++ b/Container/Containerfile
@@ -109,8 +109,10 @@ WORKDIR $CUTEST
 RUN meson setup builddir
 RUN meson compile -C builddir
 RUN meson install -C builddir
-RUN ln -s /usr/local/libcutest_single.a object/pc64.lnx.gfo/single/libcutest.a
-RUN ln -s /usr/local/libcutest_double.a object/pc64.lnx.gfo/double/libcutest.a
+RUN mkdir -p objects/pc64.lnx.gfo/single
+RUN mkdir -p objects/pc64.lnx.gfo/double
+RUN ln -s /usr/local/lib/libcutest_single.a objects/pc64.lnx.gfo/single/libcutest.a
+RUN ln -s /usr/local/lib/libcutest_double.a objects/pc64.lnx.gfo/double/libcutest.a
 
 # install pycutest
 RUN python -m pip install pycutest

--- a/Container/mantid.patch
+++ b/Container/mantid.patch
@@ -34,4 +34,60 @@ index a2f61284629..6a61faea95e 100644
 +      << extract<const char *>(PyFrame_GetCode(traceback->tb_frame)->co_filename)() << "\'";
    tracebackToStream(msg, traceback->tb_next, false);
  }
- 
+diff --git a/Framework/PythonInterface/mantid/kernel/funcinspect.py b/Framework/PythonInterface/mantid/kernel/funcinspect.py
+index e5aad721..7f59ad0a 100644
+--- a/Framework/PythonInterface/mantid/kernel/funcinspect.py
++++ b/Framework/PythonInterface/mantid/kernel/funcinspect.py
+@@ -31,52 +31,8 @@ def replace_signature(func, signature):
+     else:
+         # Drop this code when we dro Python 2 support
+         # Code object is different in Python 3
+-        if hasattr(func, "func_code"):
+-            # Version 2
+-            code_attr = "func_code"
+-            f = func.func_code
+-            c = f.__new__(
+-                f.__class__,
+-                f.co_argcount,
+-                f.co_nlocals,
+-                f.co_stacksize,
+-                f.co_flags,
+-                f.co_code,
+-                f.co_consts,
+-                f.co_names,
+-                signature,
+-                f.co_filename,
+-                f.co_name,
+-                f.co_firstlineno,
+-                f.co_lnotab,
+-                f.co_freevars,
+-            )
+-        else:
+-            code_attr = "__code__"
+-            f = func.__code__
+-            new_args = [
+-                f.__class__,
+-                f.co_argcount,
+-                f.co_kwonlyargcount,
+-                f.co_nlocals,
+-                f.co_stacksize,
+-                f.co_flags,
+-                f.co_code,
+-                f.co_consts,
+-                f.co_names,
+-                signature,
+-                f.co_filename,
+-                f.co_name,
+-                f.co_firstlineno,
+-                f.co_lnotab,
+-                f.co_freevars,
+-            ]
+-            # Python 3.8 supports positional-only arguments and has an extra
+-            # keyword in the constructor
+-            if hasattr(f, "co_posonlyargcount"):
+-                new_args.insert(2, f.co_posonlyargcount)
+-            c = f.__new__(*new_args)
+-        # endif
++        code_attr = "__code__"
++        c = func.__code__.replace(co_nlocals=2, co_varnames=signature)
+         setattr(func, code_attr, c) 


### PR DESCRIPTION
## Description of work

- [ ] Sasview fails as it only supports numpy<2.0 (but nlopt only supports numpy>2.0 now...)
- [x] Mantid wouldn't install (fixed with a patch and installing h5py without a binary)
- [x] Urllib3 needed updating
- [x] CUTEst failed at runtime (new build dir)
- [x] Gofit needs `pybind11[global]`
- [ ] Tests still fail:

I'm still running the tests locally but this is it so far... I'll add a comment when it finishes.
```
fitbenchmarking/cli/tests/test_checkpoint_handler.py ................                                                        [  2%]
fitbenchmarking/cli/tests/test_exception_handler.py ...                                                                      [  3%]
fitbenchmarking/cli/tests/test_main.py ..                                                                                    [  3%]
fitbenchmarking/controllers/tests/test_controllers.py ....................................FF.F...FFFF..FFF....FFFFFFF......s [ 16%]
ssssssssFF..F.
```

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [ ] The title is of a format appropriate for a line in future release notes.
- [ ] I have added the appropriate tags to the PR.
- [ ] My PR represents one logical piece of work.
- [ ] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [ ] I have added the appropriate tests to cover code that has been added.
- [ ] I have updated the documentation in the relevant places to cover the changes.

