### PR TITLE
Install h5py with --no-binary in container

### DIFF
--- a/Container/Containerfile
+++ b/Container/Containerfile
@@ -49,6 +49,8 @@ RUN sudo apt-get install -y cmake
 
 WORKDIR /
 
+RUN apt-get install -y pkg-config libhdf5-dev
+
 RUN git clone --depth 1 https://github.com/ISISNeutronMuon/SScanSS-2.git
 WORKDIR /SScanSS-2
 RUN python -m pip install --no-binary=h5py h5py

--- a/Container/Containerfile
+++ b/Container/Containerfile
@@ -51,6 +51,7 @@ WORKDIR /
 
 RUN git clone --depth 1 https://github.com/ISISNeutronMuon/SScanSS-2.git
 WORKDIR /SScanSS-2
+RUN python -m pip install --no-binary=h5py h5py
 RUN pip install .
 
 WORKDIR /


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1412

The new sscanss install was installing h5py but without the required `--no-binary` flag. Hopefully this solves it!

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1.
2.
3.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

