### PR TITLE
Fixed failing integration test for Mac OS - Python 3.13

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,33 +14,22 @@ jobs:
       matrix:
         os: [macos-13, windows-latest]
         python: ['3.9', '3.13']
-        exclude:
-          - os: windows-latest
-            python: '3.13'
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Set up conda
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Install python
+      uses: actions/setup-python@v5
       with:
-          miniconda-version: "latest"
-    - name: Install dependencies in conda env
-      shell: bash
+        python-version: ${{ matrix.python }}
+        check-latest: true
+    - name: Install dependencies
       run: |
-        source $CONDA/etc/profile.d/conda.sh
-        conda create -n default-test-env python=${{ matrix.python }} -y
-        conda activate default-test-env
-        conda install -c conda-forge nlopt -y
-        python -m pip install .[bumps,DFO,gradient-free,minuit,SAS,numdifftools,lmfit]
+        python -m pip install .[bumps,DFO,gradient-free,minuit,SAS,numdifftools,lmfit,nlopt]
         python -m pip install --upgrade .[dev]
-    - name: Run tests
-      shell: bash
-      run: |
-        source $CONDA/etc/profile.d/conda.sh
-        conda activate default-test-env
-        if [ "${{ matrix.os }}" == "macos-13" ]; then
-          ci/unit_tests_default.sh
-        else
-          bash ci/unit_tests_default.sh
-        fi
+    - name: Run tests (Mac)
+      if: matrix.os == 'macos-13'
+      run: ci/unit_tests_default.sh
+    - name: Run tests (Windows)
+      if: matrix.os == 'windows-latest'
+      run: bash ci/unit_tests_default.sh


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes the failing integration [tests](https://github.com/fitbenchmarking/fitbenchmarking/actions/runs/13247847947/job/36980160567). Updated the workflow to use `actions/setup-python@v5` instead of the **conda** environment. Also added the default tests for Windows (Python 3.13).

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. The integration tests will pass. Can be verified [here](https://github.com/fitbenchmarking/fitbenchmarking/actions/runs/13249267189). The tests should also pass when this PR is approved.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

