### PR TITLE
Updated table to improve readability of the initial, fitted and best parameters

### DIFF
--- a/fitbenchmarking/templates/fitting_report_template.html
+++ b/fitbenchmarking/templates/fitting_report_template.html
@@ -44,20 +44,29 @@
                                 </tr>
                                 <!-- Functions Section -->
                                 <tr>
-                                    <td class="heading" colspan="2">Functions</td>
+                                    <td class="heading" colspan="2">Function</td>
                                 </tr>
                                 <tr>
                                     <td class="label">Form</td>
                                     <td>{{ equation }}</td>
                                 </tr>
+                                <!-- Initial Parameters Section -->
                                 <tr>
-                                    <td class="label">Initial Parameters</td>
-                                    {% if list_params %}
-                                        <td>{{ initial_guess }}</td>
-                                    {% else %}
-                                        <td>Too many parameters to display</td>
-                                    {% endif %}
+                                    <td class="heading" colspan="2">Initial Parameters</td>
                                 </tr>
+                                {% if list_params %}
+                                    {% for param in initial_guess.split(", ") %}
+                                        {% set key, value = param.split("=") %}
+                                        <tr>
+                                            <td class="label">{{ key.strip() }}</td>
+                                            <td>{{ value.strip() }}</td>
+                                        </tr>
+                                    {% endfor %}
+                                {% else %}
+                                <tr>
+                                    <td colspan="2">Too many parameters to display</td>
+                                </tr>
+                                {% endif %}
                             </tbody>
                         </table>
                         <div class="row">
@@ -115,20 +124,29 @@
                             </tr>
                             <!-- Functions Section -->
                             <tr>
-                                <td class="heading" colspan="2">Functions</td>
+                                <td class="heading" colspan="2">Function</td>
                             </tr>
                             <tr>
                                 <td class="label">Form</td>
                                 <td>{{ equation }}</td>
                             </tr>
+                            <!-- Fitted Parameters Section -->
                             <tr>
-                                <td class="label">Fitted Parameters</td>
-                                {% if list_params %}
-                                    <td>{{ min_params }}</td>
-                                {% else %}
-                                    <td>Too many parameters to display</td>
-                                {% endif %}
+                                <td class="heading" colspan="2">Fitted Parameters</td>
                             </tr>
+                            {% if list_params %}
+                                {% for param in min_params.split(", ") %}
+                                    {% set key, value = param.split("=") %}
+                                    <tr>
+                                        <td class="label">{{ key.strip() }}</td>
+                                        <td>{{ value.strip() }}</td>
+                                    </tr>
+                                {% endfor %}
+                            {% else %}
+                            <tr>
+                                <td colspan="2">Too many parameters to display</td>
+                            </tr>
+                            {% endif %}
                         </tbody>
                     </table>
                     <div align="center" class="figure align-center">

--- a/fitbenchmarking/templates/fitting_report_template.html
+++ b/fitbenchmarking/templates/fitting_report_template.html
@@ -135,12 +135,14 @@
                                 <td class="heading" colspan="2">Fitted Parameters</td>
                             </tr>
                             {% if list_params %}
-                                {% for param in min_params.split(", ") %}
-                                    {% set key, value = param.split("=") %}
-                                    <tr>
-                                        <td class="label">{{ key.strip() }}</td>
-                                        <td>{{ value.strip() }}</td>
-                                    </tr>
+                                {% for param in min_params.replace("], ", "]||").split("||") %}
+                                    {% if "=" in param %}
+                                        {% set key, value = param.split("=", 1) %}
+                                        <tr>
+                                            <td class="label">{{ key.strip() }}</td>
+                                            <td>{{ value.strip() }}</td>
+                                        </tr>
+                                    {% endif %}
                                 {% endfor %}
                             {% else %}
                             <tr>

--- a/fitbenchmarking/templates/fitting_report_template.html
+++ b/fitbenchmarking/templates/fitting_report_template.html
@@ -135,14 +135,18 @@
                                 <td class="heading" colspan="2">Fitted Parameters</td>
                             </tr>
                             {% if list_params %}
-                                {% for param in min_params.replace("], ", "]||").split("||") %}
-                                    {% if "=" in param %}
-                                        {% set key, value = param.split("=", 1) %}
-                                        <tr>
-                                            <td class="label">{{ key.strip() }}</td>
-                                            <td>{{ value.strip() }}</td>
-                                        </tr>
-                                    {% endif %}
+                                {% if "[" in min_params %}
+                                    {% set formatted_params = min_params.replace("], ", "]||") %}
+                                {% else %}
+                                    {% set formatted_params = min_params.replace(", ", "||") %}
+                                {% endif %}
+                                
+                                {% for param in formatted_params.split("||") %}
+                                    {% set key, value = param.split("=", 1) %}
+                                    <tr>
+                                        <td class="label">{{ key.strip() }}</td>
+                                        <td>{{ value.strip() }}</td>
+                                    </tr>
                                 {% endfor %}
                             {% else %}
                             <tr>

--- a/fitbenchmarking/templates/problem_summary_page_template.html
+++ b/fitbenchmarking/templates/problem_summary_page_template.html
@@ -46,20 +46,29 @@
                             </tr>
                             <!-- Functions Section -->
                             <tr>
-                                <td class="heading" colspan="2">Functions</td>
+                                <td class="heading" colspan="2">Function</td>
                             </tr>
                             <tr>
                                 <td class="label">Form</td>
                                 <td>{{ equation }}</td>
                             </tr>
+                            <!-- Initial Parameters Section -->
                             <tr>
-                                <td class="label">Initial Parameters</td>
-                                {% if list_params %}
-                                    <td>{{ initial_guess }}</td>
-                                {% else %}
-                                    <td>Too many parameters to display</td>
-                                {% endif %}
+                                <td class="heading" colspan="2">Initial Parameters</td>
                             </tr>
+                            {% if list_params %}
+                                {% for param in initial_guess.split(", ") %}
+                                    {% set key, value = param.split("=") %}
+                                    <tr>
+                                        <td class="label">{{ key.strip() }}</td>
+                                        <td>{{ value.strip() }}</td>
+                                    </tr>
+                                {% endfor %}
+                            {% else %}
+                            <tr>
+                                <td colspan="2">Too many parameters to display</td>
+                            </tr>
+                            {% endif %}
                         </tbody>
                     </table>
                     <div class="row">
@@ -129,20 +138,29 @@
                                 </tr>
                                 <!-- Functions Section -->
                                 <tr>
-                                    <td class="heading" colspan="2">Functions</td>
+                                    <td class="heading" colspan="2">Function</td>
                                 </tr>
                                 <tr>
                                     <td class="label">Form</td>
                                     <td>{{ equation }}</td>
                                 </tr>
+                                <!-- Best Parameters Section -->
                                 <tr>
-                                    <td class="label">Best Parameters</td>
-                                    {% if list_params %}
-                                        <td>{{ min_params }}</td>
-                                    {% else %}
-                                        <td>Too many parameters to display</td>
-                                    {% endif %}
+                                    <td class="heading" colspan="2">Best Parameters</td>
                                 </tr>
+                                {% if list_params %}
+                                    {% for param in min_params.split(", ") %}
+                                        {% set key, value = param.split("=") %}
+                                        <tr>
+                                            <td class="label">{{ key.strip() }}</td>
+                                            <td>{{ value.strip() }}</td>
+                                        </tr>
+                                    {% endfor %}
+                                {% else %}
+                                <tr>
+                                    <td colspan="2">Too many parameters to display</td>
+                                </tr>
+                                {% endif %}
                             </tbody>
                         </table>
                         <div align="center" class="figure align-center">
@@ -181,20 +199,29 @@
                                     </tr>
                                     <!-- Functions Section -->
                                     <tr>
-                                        <td class="heading" colspan="2">Functions</td>
+                                        <td class="heading" colspan="2">Function</td>
                                     </tr>
                                     <tr>
                                         <td class="label">Form</td>
                                         <td>{{ equation }}</td>
                                     </tr>
+                                    <!-- Best Parameters Section -->
                                     <tr>
-                                        <td class="label">Best Parameters</td>
-                                        {% if list_params %}
-                                            <td>{{ min_params }}</td>
-                                        {% else %}
-                                            <td>Too many parameters to display</td>
-                                        {% endif %}
+                                        <td class="heading" colspan="2">Best Parameters</td>
                                     </tr>
+                                    {% if list_params %}
+                                        {% for param in min_params.split(", ") %}
+                                            {% set key, value = param.split("=") %}
+                                            <tr>
+                                                <td class="label">{{ key.strip() }}</td>
+                                                <td>{{ value.strip() }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    {% else %}
+                                    <tr>
+                                        <td colspan="2">Too many parameters to display</td>
+                                    </tr>
+                                    {% endif %}
                                 </tbody>
                             </table>
                             <div align="center" class="figure align-center">

--- a/fitbenchmarking/templates/problem_summary_page_template.html
+++ b/fitbenchmarking/templates/problem_summary_page_template.html
@@ -149,12 +149,14 @@
                                     <td class="heading" colspan="2">Best Parameters</td>
                                 </tr>
                                 {% if list_params %}
-                                    {% for param in min_params.split(", ") %}
-                                        {% set key, value = param.split("=") %}
-                                        <tr>
-                                            <td class="label">{{ key.strip() }}</td>
-                                            <td>{{ value.strip() }}</td>
-                                        </tr>
+                                    {% for param in min_params.replace("], ", "]||").split("||") %}
+                                        {% if "=" in param %}
+                                            {% set key, value = param.split("=", 1) %}
+                                            <tr>
+                                                <td class="label">{{ key.strip() }}</td>
+                                                <td>{{ value.strip() }}</td>
+                                            </tr>
+                                        {% endif %}
                                     {% endfor %}
                                 {% else %}
                                 <tr>
@@ -210,12 +212,14 @@
                                         <td class="heading" colspan="2">Best Parameters</td>
                                     </tr>
                                     {% if list_params %}
-                                        {% for param in min_params.split(", ") %}
-                                            {% set key, value = param.split("=") %}
-                                            <tr>
-                                                <td class="label">{{ key.strip() }}</td>
-                                                <td>{{ value.strip() }}</td>
-                                            </tr>
+                                        {% for param in min_params.replace("], ", "]||").split("||") %}
+                                            {% if "=" in param %}
+                                                {% set key, value = param.split("=", 1) %}
+                                                <tr>
+                                                    <td class="label">{{ key.strip() }}</td>
+                                                    <td>{{ value.strip() }}</td>
+                                                </tr>
+                                            {% endif %}
                                         {% endfor %}
                                     {% else %}
                                     <tr>

--- a/fitbenchmarking/templates/problem_summary_page_template.html
+++ b/fitbenchmarking/templates/problem_summary_page_template.html
@@ -149,14 +149,18 @@
                                     <td class="heading" colspan="2">Best Parameters</td>
                                 </tr>
                                 {% if list_params %}
-                                    {% for param in min_params.replace("], ", "]||").split("||") %}
-                                        {% if "=" in param %}
-                                            {% set key, value = param.split("=", 1) %}
-                                            <tr>
-                                                <td class="label">{{ key.strip() }}</td>
-                                                <td>{{ value.strip() }}</td>
-                                            </tr>
-                                        {% endif %}
+                                    {% if "[" in min_params %}
+                                        {% set formatted_params = min_params.replace("], ", "]||") %}
+                                    {% else %}
+                                        {% set formatted_params = min_params.replace(", ", "||") %}
+                                    {% endif %}
+                                    
+                                    {% for param in formatted_params.split("||") %}
+                                        {% set key, value = param.split("=", 1) %}
+                                        <tr>
+                                            <td class="label">{{ key.strip() }}</td>
+                                            <td>{{ value.strip() }}</td>
+                                        </tr>
                                     {% endfor %}
                                 {% else %}
                                 <tr>
@@ -212,14 +216,18 @@
                                         <td class="heading" colspan="2">Best Parameters</td>
                                     </tr>
                                     {% if list_params %}
-                                        {% for param in min_params.replace("], ", "]||").split("||") %}
-                                            {% if "=" in param %}
-                                                {% set key, value = param.split("=", 1) %}
-                                                <tr>
-                                                    <td class="label">{{ key.strip() }}</td>
-                                                    <td>{{ value.strip() }}</td>
-                                                </tr>
-                                            {% endif %}
+                                        {% if "[" in min_params %}
+                                            {% set formatted_params = min_params.replace("], ", "]||") %}
+                                        {% else %}
+                                            {% set formatted_params = min_params.replace(", ", "||") %}
+                                        {% endif %}
+                                        
+                                        {% for param in formatted_params.split("||") %}
+                                            {% set key, value = param.split("=", 1) %}
+                                            <tr>
+                                                <td class="label">{{ key.strip() }}</td>
+                                                <td>{{ value.strip() }}</td>
+                                            </tr>
                                         {% endfor %}
                                     {% else %}
                                     <tr>


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Updated the table template to separate out the variables and make them more readable at a glance.  

**Before**
<img width="1034" alt="Screenshot 2025-02-17 at 17 29 16" src="https://github.com/user-attachments/assets/2f6f4889-231b-443f-9ca0-11f72e8ccdef" />

**After**
<img width="1026" alt="Screenshot 2025-02-17 at 17 57 17" src="https://github.com/user-attachments/assets/6213e3a0-5415-49c4-848d-6b4b48edbe26" />


<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Run `fitbenchmarking` and verify tables are updated in the fitting report and problem summary pages.
2. Run `fitbenchmarking -p examples/benchmark_problems/MultiFit -s mantid` and verify tables are updated for the multifit datasets.
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/2079a4a3-076f-4207-83d4-15b3e8ca21c6" />

**Note** - The fitted and best parameters are shown as lists. But this should not be the case. An issue has been created to fix this bug.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
      #1430 
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

