### PR TITLE
Added check/processing on dash component ids

### DIFF
--- a/fitbenchmarking/results_processing/performance_profiler.py
+++ b/fitbenchmarking/results_processing/performance_profiler.py
@@ -433,6 +433,10 @@ class DashPerfProfile:
         self.group_label = group_label
         self.id = self.group_label + "-" + self.profile_name
 
+        dash_not_allowed_characters = [".", "{"]
+        for character in dash_not_allowed_characters:
+            self.id = self.id.replace(character, "")
+
         self.default_opt = []
         for solver in self.data.columns:
             self.default_opt.append({"value": solver, "label": solver})


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

This is to check whether dash component ids contain any of the characters not allowed by Dash ( "." and "{" ) and remove these characters before creating the plot.

Fixes #1304 .

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

To check this, the path to the problems being run (provided in the command line) needs to include e.g. ".."  . Fitbenchmarking uses the path to determine the id to assign to Dash components. So the changes in this PR aim at removing characters not allowed by Dash (like ".") from the Dash component id, before creating the component.

I checked the changes by:
1. moving a folder with specific problems (e.g. SIF) to outside the folder "examples" . 
2. then running:    fitbenchmarking -p /home/letizia/fitbenchmarking/examples/../SIF

This only works through the changes in this PR. Otherwise Dash raises an error.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

