### PR TITLE
Fixed the partial cell rendering when error flag is 2

### DIFF
--- a/fitbenchmarking/results_processing/compare_table.py
+++ b/fitbenchmarking/results_processing/compare_table.py
@@ -119,13 +119,15 @@ class CompareTable(Table):
         )
 
     @staticmethod
-    def vals_to_colour(vals, cmap, cmap_range, log_ulim):
+    def vals_to_colour(vals, flags, cmap, cmap_range, log_ulim):
         """
         Override vals_to_colour to allow it to run for both accuracy and
         runtime.
 
         :param vals: The relative values to get the colours for
         :type vals: list[list[float, float]]
+        :param flags: The flags associated with the results
+        :type flags: list[int]
         :param cmap: matplotlib colourmap
         :type cmap: matplotlib colourmap object
         :param cmap_range: values in range [0, 1] for colourmap cropping
@@ -139,10 +141,10 @@ class CompareTable(Table):
         """
         acc, runtime = zip(*vals)
         acc_colours, acc_text = Table.vals_to_colour(
-            acc, cmap, cmap_range, log_ulim
+            acc, flags, cmap, cmap_range, log_ulim
         )
         runtime_colours, runtime_text = Table.vals_to_colour(
-            runtime, cmap, cmap_range, log_ulim
+            runtime, flags, cmap, cmap_range, log_ulim
         )
         background_col = zip(acc_colours, runtime_colours)
         foreground_text = zip(acc_text, runtime_text)

--- a/fitbenchmarking/results_processing/local_min_table.py
+++ b/fitbenchmarking/results_processing/local_min_table.py
@@ -130,7 +130,7 @@ class LocalMinTable(Table):
         return local_min, norm_rel
 
     @staticmethod
-    def vals_to_colour(vals, cmap, cmap_range, log_ulim):
+    def vals_to_colour(vals, flags, cmap, cmap_range, log_ulim):
         """
         Converts an array of values to a list of hexadecimal colour strings
         using sampling from a matplotlib colourmap according to whether a
@@ -141,6 +141,8 @@ class LocalMinTable(Table):
 
         :param vals: values in the range [0, 1] to convert to colour strings
         :type vals: list[float]
+        :param flags: The flags associated with the results
+        :type flags: list[int]
         :param cmap: matplotlib colourmap
         :type cmap: matplotlib colourmap object
         :param cmap_range: values in range [0, 1] for colourmap cropping


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1289

As mentioned in the issue, the cells are partially coloured when the accuracy in **infinity** and runtime is **finite**. This happens when `controller.eval_chisq` returns **infinity** because the fitting benchmark did not result in finding good parameters. The error code in this case is 2 which means that the software did not converge to a solution. 

<img width="606" alt="image" src="https://github.com/user-attachments/assets/547aaa49-1d6d-4f26-b33b-3cf7a5170f3e" />


This is technically not an error. I have updated the tables to show the results in this case as follows.
<img width="116" alt="image" src="https://github.com/user-attachments/assets/cf2b8295-3443-4281-b5df-283cd095e761" />


This is done so that the user can update the problem definition file to check the algorithm performance with different ranges of data or different starting conditions etc. Doing it this way also means that the result summary page is linked and the user can view the results of the fitting benchmark even though they are not great.

<img width="668" alt="image" src="https://github.com/user-attachments/assets/b56e5cb1-dfbe-4c32-a39a-f208ec52f94d" />


 

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->
I was able to recreate the bug using the `mantid` software with the `DampedGaussian` algorithm on the **MGH17** dataset.

1. Create a options file called **tmp.ini** in the main folder with the following content.
```
[FITTING]

software: mantid
          scipy_ls

num_runs: 1
max_runtime: 600

[MINIMIZERS]

mantid: Damped GaussNewton
```
2. Run `fitbenchmarking -o tmp.ini`
3. Verify the tables show the following
<img width="924" alt="Screenshot 2025-02-25 at 15 15 04" src="https://github.com/user-attachments/assets/be4f366d-e14e-4d1c-b0e7-b136f1da51e9" />


## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

