### PR TITLE
Added SLF ruleset to check private member access through ruff

### DIFF
--- a/fitbenchmarking/controllers/bumps_controller.py
+++ b/fitbenchmarking/controllers/bumps_controller.py
@@ -120,10 +120,7 @@ class BumpsController(Controller):
 
         # Determine the order of the parameters in `self.fit_problem` as this
         # could differ from the ordering of parameters in `self._param_names`
-        self.fit_order = [
-            str(self._fit_problem._parameters[i])
-            for i in range(len(self._param_names))
-        ]
+        self.fit_order = self._fit_problem.labels()
 
         if self.minimizer == "lm-bumps":
             self._minimizer = "lm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,13 +131,22 @@ select = [
     "C4", # flake8-comprehensions
     "TCH", # flake8-type-checking
     "G", # flake8-logging-format
+    "PIE", # flake8-pie
+    "SLF", # flake8-self
     "RUF", # ruff-specific-rules
     "FURB", # refurb
     "FLY", # flynt
-    "PIE", # flake8-pie
     "PD", # pandas-vet
     ]
 ignore = ["PERF203", "RUF012", "RUF015", "RUF019"]
+
+[tool.ruff.lint.per-file-ignores]
+"fitbenchmarking/core/tests/test_fitting_benchmarking.py" = ["SLF001"]
+"fitbenchmarking/parsing/tests/test_fitbenchmark_parser.py" = ["SLF001"]
+"fitbenchmarking/utils/tests/test_options_generic.py" = ["SLF001"]
+"fitbenchmarking/results_processing/tests/test_problem_summary_page.py" = ["SLF001"]
+"fitbenchmarking/controllers/tests/test_controllers.py" = ["SLF001"]
+"fitbenchmarking/results_processing/tests/test_plots.py" = ["SLF001"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

It would be nice to have an explicit check to verify that private members are not accessed in the code base besides in test files for testing behaviour. A private member was being accessed in the `bumps` controller. The code has been updated to use the [labels()](https://github.com/bumps/bumps/blob/4af0401c27fc88ebe41b5745f24e9287779a2b84/bumps/fitproblem.py#L530) method instead of accessing **_parameters**.

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. run `ruff check .` and verify that **All checks passed!**
2. run `ruff format .` and verify no warnings are raised.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

