### PR TITLE
Added new dropdown menus for filtering the software and cost function results

### DIFF
--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -435,7 +435,7 @@ class Table:
         minimizer_template = (
             '<a class="minimizer_header" col={0} '
             'title="{1}"'
-            'data-software="{2}"'
+            ' data-software="{2}" '
             'href="https://fitbenchmarking.readthedocs.io/'
             "en/latest/users/options/minimizer_option.html"
             '#{2}" target="_blank">{3}</a>'
@@ -751,7 +751,7 @@ class Table:
         items = [
             f'        <li><label class="noselect"><input '
             f'type="checkbox" checked=true value="{minimizer}"'
-            f"onclick=\"toggle_minimizer('{software}', "
+            f" onclick=\"toggle_minimizer('{software}', "
             f"'{minimizer}')\"/> {minimizer}</label></li>"
             for software, minimizer in minimizers
         ]

--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -540,11 +540,17 @@ class Table:
         html = {}
         for name in [self.name, self.options.comparison_mode]:
             descrip = FORMAT_DESCRIPTION[name]
-            if self.name in ["compare", "acc"] and name in ["rel", "both"]:
+            if name in ["rel", "both"]:
                 descrip += (
-                    " Incase of a perfect fit on"
-                    " a problem ``rel = abs / 1e-10``."
+                    " The relative values are calculated by comparing"
+                    " all minimizer results. Unselecting software(s) or"
+                    " minimizer(s) will not update the relative values."
                 )
+                if self.name in ["compare", "acc"]:
+                    descrip += (
+                        " Incase of a perfect fit on"
+                        " a problem ``rel = abs / 1e-10``."
+                    )
             descrip = descrip.replace(":ref:", "")
             js = get_js(self.options, self.group_dir)
             docsettings = {"math_output": "MathJax " + js["mathjax"]}

--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -435,6 +435,7 @@ class Table:
         minimizer_template = (
             '<a class="minimizer_header" col={0} '
             'title="{1}"'
+            'data-software="{2}"'
             'href="https://fitbenchmarking.readthedocs.io/'
             "en/latest/users/options/minimizer_option.html"
             '#{2}" target="_blank">{3}</a>'
@@ -749,7 +750,7 @@ class Table:
 
         items = [
             f'        <li><label class="noselect"><input '
-            f'type="checkbox" checked=true '
+            f'type="checkbox" checked=true value="{minimizer}"'
             f"onclick=\"toggle_minimizer('{software}', "
             f"'{minimizer}')\"/> {minimizer}</label></li>"
             for software, minimizer in minimizers
@@ -757,6 +758,48 @@ class Table:
 
         return self._dropdown_html(
             "minimizer_dropdown", "Select Minimizers", items
+        )
+
+    def software_dropdown_html(self) -> str:
+        """
+        Generates the HTML for a dropdown checklist of software.
+
+        :return: HTML for a dropdown checklist of softwares.
+        :rtype: str
+        """
+        label_template = (
+            "        <li><label class='noselect'><input "
+            "type='checkbox' checked=true value='{0}' "
+            "onclick=\"toggle_software('{0}')"
+            '"/>{0}</label></li>'
+        )
+        items = [
+            label_template.format(software.replace("_", "-"))
+            for software in self.options.software
+        ]
+        return self._dropdown_html(
+            "software_dropdown", "Select Softwares", items
+        )
+
+    def costfunc_dropdown_html(self) -> str:
+        """
+        Generates the HTML for a dropdown checklist of cost functions.
+
+        :return: HTML for a dropdown checklist of cost functions.
+        :rtype: str
+        """
+        label_template = (
+            '        <li><label class="noselect"><input '
+            'type="checkbox" checked=true value="{0}"'
+            "onclick=\"toggle_cost_function('{0}')\"/>"
+            "{0}</label></li>"
+        )
+        items = [
+            label_template.format(cost_func)
+            for cost_func in self.options.cost_func_type
+        ]
+        return self._dropdown_html(
+            "costfunc_dropdown", "Select Cost Functions", items
         )
 
     def runtime_dropdown_html(self) -> str:

--- a/fitbenchmarking/results_processing/base_table.py
+++ b/fitbenchmarking/results_processing/base_table.py
@@ -8,6 +8,8 @@ from abc import ABCMeta, abstractmethod
 import docutils.core
 import matplotlib as mpl
 
+from fitbenchmarking.cost_func.cost_func_factory import create_cost_func
+
 mpl.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
@@ -794,10 +796,11 @@ class Table:
             "onclick=\"toggle_cost_function('{0}')\"/>"
             "{0}</label></li>"
         )
-        items = [
-            label_template.format(cost_func)
-            for cost_func in self.options.cost_func_type
-        ]
+        items = []
+        for cost_func in self.options.cost_func_type:
+            name = create_cost_func(cost_func).__name__.lower()
+            items.append(label_template.format(name))
+
         return self._dropdown_html(
             "costfunc_dropdown", "Select Cost Functions", items
         )

--- a/fitbenchmarking/results_processing/tables.py
+++ b/fitbenchmarking/results_processing/tables.py
@@ -124,6 +124,9 @@ def create_results_tables(
             key11 = list(results[key1].keys())[0]
             n_solvers = len(results[key1][key11])
             n_solvers_large = n_solvers > 15
+            has_multiple_softwares = len(options.software) > 1
+            has_multiple_costfuncs = len(options.cost_func_type) > 1
+            has_multiple_minimizers = len(options.minimizers) > 1
 
             with open(f"{table.file_path}html", "w", encoding="utf-8") as f:
                 f.write(
@@ -137,7 +140,12 @@ def create_results_tables(
                         table_js=js["table"],
                         table=html["table"],
                         problem_dropdown=html["problem_dropdown"],
+                        costfunc_dropdown=html["costfunc_dropdown"],
+                        has_multiple_costfuncs=has_multiple_costfuncs,
+                        software_dropdown=html["software_dropdown"],
+                        has_multiple_softwares=has_multiple_softwares,
                         minimizer_dropdown=html["minim_dropdown"],
+                        has_multiple_minimizers=has_multiple_minimizers,
                         probsize_checkbox=html["probsize_checkbox"],
                         runtime_dropdown=html["runtime_dropdown"],
                         table_description=description[suffix],
@@ -248,6 +256,8 @@ def generate_table(
         "problem_dropdown": table.problem_dropdown_html(),
         "minim_dropdown": table.minimizer_dropdown_html(),
         "probsize_checkbox": table.probsize_checkbox_html(),
+        "software_dropdown": table.software_dropdown_html(),
+        "costfunc_dropdown": table.costfunc_dropdown_html(),
         "runtime_dropdown": "",
     }
 

--- a/fitbenchmarking/results_processing/tables.py
+++ b/fitbenchmarking/results_processing/tables.py
@@ -124,9 +124,6 @@ def create_results_tables(
             key11 = list(results[key1].keys())[0]
             n_solvers = len(results[key1][key11])
             n_solvers_large = n_solvers > 15
-            has_multiple_softwares = len(options.software) > 1
-            has_multiple_costfuncs = len(options.cost_func_type) > 1
-            has_multiple_minimizers = len(options.minimizers) > 1
 
             with open(f"{table.file_path}html", "w", encoding="utf-8") as f:
                 f.write(
@@ -141,11 +138,8 @@ def create_results_tables(
                         table=html["table"],
                         problem_dropdown=html["problem_dropdown"],
                         costfunc_dropdown=html["costfunc_dropdown"],
-                        has_multiple_costfuncs=has_multiple_costfuncs,
                         software_dropdown=html["software_dropdown"],
-                        has_multiple_softwares=has_multiple_softwares,
                         minimizer_dropdown=html["minim_dropdown"],
-                        has_multiple_minimizers=has_multiple_minimizers,
                         probsize_checkbox=html["probsize_checkbox"],
                         runtime_dropdown=html["runtime_dropdown"],
                         table_description=description[suffix],

--- a/fitbenchmarking/results_processing/tests/expected_results/acc.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/acc.html
@@ -46,14 +46,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/acc.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/acc.html
@@ -46,14 +46,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/compare.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/compare.html
@@ -49,14 +49,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/compare.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/compare.html
@@ -49,14 +49,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/energy_usage.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/energy_usage.html
@@ -28,14 +28,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/energy_usage.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/energy_usage.html
@@ -28,14 +28,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/local_min.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/local_min.html
@@ -22,14 +22,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/local_min.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/local_min.html
@@ -22,14 +22,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/minimizer_dropdown.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/minimizer_dropdown.html
@@ -1,13 +1,13 @@
 <div id="minimizer_dropdown" class="dropdown-check-list" tabindex="100">
     <span class="anchor" onclick="show_dropdown('minimizer_dropdown')">Select Minimizers</span>
     <ul class="items">
-        <li><label class="noselect"><input type="checkbox" checked=true onclick="toggle_minimizer('s0', 'm00: j:j0')"/> m00: j:j0</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true onclick="toggle_minimizer('s0', 'm00: j:j1')"/> m00: j:j1</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true onclick="toggle_minimizer('s0', 'm01: j:j0')"/> m01: j:j0</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true onclick="toggle_minimizer('s0', 'm01: j:j1')"/> m01: j:j1</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true onclick="toggle_minimizer('s1', 'm10: j:j0')"/> m10: j:j0</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true onclick="toggle_minimizer('s1', 'm10: j:j1')"/> m10: j:j1</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true onclick="toggle_minimizer('s1', 'm11: j:j0')"/> m11: j:j0</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true onclick="toggle_minimizer('s1', 'm11: j:j1')"/> m11: j:j1</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m00: j:j0"onclick="toggle_minimizer('s0', 'm00: j:j0')"/> m00: j:j0</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m00: j:j1"onclick="toggle_minimizer('s0', 'm00: j:j1')"/> m00: j:j1</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m01: j:j0"onclick="toggle_minimizer('s0', 'm01: j:j0')"/> m01: j:j0</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m01: j:j1"onclick="toggle_minimizer('s0', 'm01: j:j1')"/> m01: j:j1</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m10: j:j0"onclick="toggle_minimizer('s1', 'm10: j:j0')"/> m10: j:j0</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m10: j:j1"onclick="toggle_minimizer('s1', 'm10: j:j1')"/> m10: j:j1</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m11: j:j0"onclick="toggle_minimizer('s1', 'm11: j:j0')"/> m11: j:j0</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m11: j:j1"onclick="toggle_minimizer('s1', 'm11: j:j1')"/> m11: j:j1</label></li>
     </ul>
 </div>

--- a/fitbenchmarking/results_processing/tests/expected_results/minimizer_dropdown.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/minimizer_dropdown.html
@@ -1,13 +1,13 @@
 <div id="minimizer_dropdown" class="dropdown-check-list" tabindex="100">
     <span class="anchor" onclick="show_dropdown('minimizer_dropdown')">Select Minimizers</span>
     <ul class="items">
-        <li><label class="noselect"><input type="checkbox" checked=true value="m00: j:j0"onclick="toggle_minimizer('s0', 'm00: j:j0')"/> m00: j:j0</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true value="m00: j:j1"onclick="toggle_minimizer('s0', 'm00: j:j1')"/> m00: j:j1</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true value="m01: j:j0"onclick="toggle_minimizer('s0', 'm01: j:j0')"/> m01: j:j0</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true value="m01: j:j1"onclick="toggle_minimizer('s0', 'm01: j:j1')"/> m01: j:j1</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true value="m10: j:j0"onclick="toggle_minimizer('s1', 'm10: j:j0')"/> m10: j:j0</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true value="m10: j:j1"onclick="toggle_minimizer('s1', 'm10: j:j1')"/> m10: j:j1</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true value="m11: j:j0"onclick="toggle_minimizer('s1', 'm11: j:j0')"/> m11: j:j0</label></li>
-        <li><label class="noselect"><input type="checkbox" checked=true value="m11: j:j1"onclick="toggle_minimizer('s1', 'm11: j:j1')"/> m11: j:j1</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m00: j:j0" onclick="toggle_minimizer('s0', 'm00: j:j0')"/> m00: j:j0</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m00: j:j1" onclick="toggle_minimizer('s0', 'm00: j:j1')"/> m00: j:j1</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m01: j:j0" onclick="toggle_minimizer('s0', 'm01: j:j0')"/> m01: j:j0</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m01: j:j1" onclick="toggle_minimizer('s0', 'm01: j:j1')"/> m01: j:j1</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m10: j:j0" onclick="toggle_minimizer('s1', 'm10: j:j0')"/> m10: j:j0</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m10: j:j1" onclick="toggle_minimizer('s1', 'm10: j:j1')"/> m10: j:j1</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m11: j:j0" onclick="toggle_minimizer('s1', 'm11: j:j0')"/> m11: j:j0</label></li>
+        <li><label class="noselect"><input type="checkbox" checked=true value="m11: j:j1" onclick="toggle_minimizer('s1', 'm11: j:j1')"/> m11: j:j1</label></li>
     </ul>
 </div>

--- a/fitbenchmarking/results_processing/tests/expected_results/runtime.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/runtime.html
@@ -43,14 +43,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]" data-software="s0" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]" data-software="s1" href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/results_processing/tests/expected_results/runtime.html
+++ b/fitbenchmarking/results_processing/tests/expected_results/runtime.html
@@ -43,14 +43,14 @@
     <tr>
       <th class="blank" >&nbsp;</th>
       <th class="blank level2" >&nbsp;</th>
-      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
-      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
-      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
-      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
-      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
-      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
-      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
-      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
+      <th id="T_table_level2_col0" class="col_heading level2 col0" ><a class="minimizer_header" col=0 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j0</a></th>
+      <th id="T_table_level2_col1" class="col_heading level2 col1" ><a class="minimizer_header" col=1 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m00: j:j1</a></th>
+      <th id="T_table_level2_col2" class="col_heading level2 col2" ><a class="minimizer_header" col=2 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j0</a></th>
+      <th id="T_table_level2_col3" class="col_heading level2 col3" ><a class="minimizer_header" col=3 title="[]"data-software="s0"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s0" target="_blank">m01: j:j1</a></th>
+      <th id="T_table_level2_col4" class="col_heading level2 col4" ><a class="minimizer_header" col=4 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j0</a></th>
+      <th id="T_table_level2_col5" class="col_heading level2 col5" ><a class="minimizer_header" col=5 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m10: j:j1</a></th>
+      <th id="T_table_level2_col6" class="col_heading level2 col6" ><a class="minimizer_header" col=6 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j0</a></th>
+      <th id="T_table_level2_col7" class="col_heading level2 col7" ><a class="minimizer_header" col=7 title="[]"data-software="s1"href="https://fitbenchmarking.readthedocs.io/en/latest/users/options/minimizer_option.html#s1" target="_blank">m11: j:j1</a></th>
     </tr>
   </thead>
   <tbody>

--- a/fitbenchmarking/templates/css/custom_style.css
+++ b/fitbenchmarking/templates/css/custom_style.css
@@ -78,6 +78,11 @@ a {
   zoom: 0.99;
 }
 
+.checkbox-row {
+  margin-top: 10px;
+  display: block;
+}
+
 .pill {
   display: inline-block;
   padding: 5px 10px;

--- a/fitbenchmarking/templates/js/table.js
+++ b/fitbenchmarking/templates/js/table.js
@@ -45,23 +45,17 @@ function toggle_problem(problem_name) {
 * @param   {String} minimizer  The name of the minimizer as it appears in the table column header.
 * @param   {Boolean} independent_call  Determines if the function is called independently or from toggle_softwares.
 */
-function toggle_minimizer(software, minimizer, independent_call = true) {
-    var cost_function_header = $("a.cost_function_header").parent();
+function toggle_minimizer(software, minimizer) {
     var software_header = _find_element_from_text("a.software_header", software).parent();
     var minimizer_text = _find_element_from_text("a.minimizer_header", minimizer);
     var minimizer_header = minimizer_text.parent();
 
     // Get the checkbox status
     var is_checked = $(`input[type="checkbox"][value="${minimizer}"]`).is(':checked');
-    if (independent_call){
-        // calls helper function if the minimizer is 
-        // toggled from the minimizer dropdown menu. 
-        _handle_independent_call(software)
-    } else {
-        // update status if minimizer toggled from
-        // the software dropdown menu.
-        is_checked = $(`input[type="checkbox"][value="${software}"]`).is(':checked');
-    }
+
+    // calls helper function if the minimizer is 
+    // toggled from the minimizer dropdown menu. 
+    _handle_disabling_software_checkbox(software)
 
     // Toggle the minimizer header based on is_checked
     if (is_checked) {
@@ -70,9 +64,36 @@ function toggle_minimizer(software, minimizer, independent_call = true) {
         minimizer_header.hide();
     }
 
-    // Adjusts the Cost function and software headers
-    _adjust_colspan(cost_function_header, is_checked);
-    _adjust_colspan(software_header, is_checked);
+    const cost_func_names = _get_cost_func_names();
+    cost_func_names.forEach(function(cost_func){
+        // Get the data cell ids for a given cost function 
+        const [_, cols] = _get_all_data_cell_ids(cost_func)
+        var width = _get_cost_func_header_span(cost_func);
+
+        // Adjust the column width of the cost function header
+        var cost_function_header = $('th a.cost_function_header').filter(function () {
+            return $(this).text().trim().toLowerCase() === cost_func;
+        }).parent();
+        cost_function_header.attr('colspan', width);
+
+        // Adjust the column width of the software
+        const software_names = _get_software_names();
+        software_names.forEach(function(name){
+            const header = $('th a.software_header').filter(function () {
+                const name_check = $(this).text().trim() === name;
+                const thId = $(this).parent().attr('id');
+                const colMatch = thId.match(/col\d+$/);
+                const col = colMatch ? colMatch[0] : null;
+                return name_check && cols.includes(col);
+            }).parent();
+            var width = _get_software_header_span(cost_func, name);
+            if (width == 0) {
+                header.hide();
+            } else {
+                header.attr('colspan', width);
+            }
+        })
+    })
 
     // Toggle the data cells in a column
     var table_id = software_header.parent().parent().parent().attr("id");
@@ -102,11 +123,76 @@ function _get_minimizer_names(software){
 }
 
 /**
+ * Returns the span of the cost function header.
+ * @param {String} cost_func - The name of the cost function.
+ */
+function _get_cost_func_header_span(cost_func) {
+    const [_, cols] = _get_all_data_cell_ids(cost_func)
+    var width = 0;
+    cols.forEach(function(col) {
+        const th = $(`#T_table_level2_${col}`);
+        if (th.is(':visible')){
+            width += 1
+        }
+    })
+    return width;
+}
+
+/**
+ * Returns the span of the cost function header.
+ * @param {String} cost_func - The name of the cost function.
+ */
+function _get_software_header_span(cost_func, software) {
+    const [_, cols] = _get_all_data_cell_ids(cost_func)
+    // Select the minimizer headers
+    const updated_cols = []
+    cols.forEach(function(col) {
+        const th = $(`#T_table_level2_${col}`);
+        const link = th.find('a.minimizer_header');
+        if (link.data('software') === software) {
+            updated_cols.push(col)
+        }
+    });
+    var width = 0;
+    updated_cols.forEach(function(col) {
+        const th = $(`#T_table_level2_${col}`);
+        if (th.is(':visible')){
+            width += 1
+        }
+    })
+    return width;
+}
+
+/**
+* Helper function that extracts the names of the cost function used while benchmarking.
+*/
+function _get_cost_func_names(){
+    var costfunc_names = []
+    var cost_function_headers = $('th a.cost_function_header')
+    cost_function_headers.each(function () {
+        costfunc_names.push($(this).text().trim().toLowerCase());
+    });
+    return costfunc_names
+}
+
+/**
+* Helper function that extracts the names of the software used while benchmarking.
+*/
+function _get_software_names(){
+    var software_names = []
+    var software_headers = $('th a.software_header')
+    software_headers.each(function () {
+        software_names.push($(this).text().trim());
+    });
+    return [...new Set(software_names)]
+}
+
+/**
 * Handles the case when a minimizer is toggled directly from the
 * minimizer dropdown, rather than through the software dropdown.
 * @param {String} software - The name of the software.
 */
-function _handle_independent_call(software){
+function _handle_disabling_software_checkbox(software){
     var software_checkboxes = $(`input[type="checkbox"][value="${software}"]`);
     var software_has_single_minimizer = false;
     
@@ -149,22 +235,87 @@ function _handle_independent_call(software){
 * @param   {String} software   The name of the software.
 */
 function toggle_software(software) {
-    var software_header = _find_element_from_text("a.software_header", software).parent();
-    
-    // Toggle the software header based on status of checkbox
     const is_checked = $(`input[type="checkbox"][value="${software}"]`).is(':checked');
-    if (is_checked) {
-        software_header.show();
-    } else {
-        software_header.hide();
-    }
+    
+    // Retrive cost functions used while benchmarking
+    const cost_func_names = _get_cost_func_names();
+
+    // Process each cost function
+    cost_func_names.forEach(function (cost_func) {
+
+        var cost_function_header = $('th a.cost_function_header').filter(function () {
+            return $(this).text().trim().toLowerCase() === cost_func;
+        }).parent();
+        const cost_function_is_checked = $(`input[type="checkbox"][value="${cost_func}"]`).is(':checked');
+
+        if (cost_function_is_checked){
+
+            // Get the data cell ids for a given cost function 
+            const [matching_ids, cols] = _get_all_data_cell_ids(cost_func)
+
+            // Select the minimizer headers
+            const minimizer_headers = [];
+            const updated_cols = []
+            cols.forEach(function(col) {
+                const th = $(`#T_table_level2_${col}`);
+                const link = th.find('a.minimizer_header');
+                if (link.data('software') === software) {
+                    minimizer_headers.push(th.attr('id'));
+                    updated_cols.push(col)
+                }
+            });
+
+            // Hide/Show the minimizer headers
+            minimizer_headers.forEach(function (header) {
+                if (is_checked){
+                    $('#' + header).show();
+                } else {
+                    $('#' + header).hide();
+                }
+            });
+
+            // Select the software headers
+            const software_headers = [];
+            updated_cols.forEach(function(col) {
+                const th = $(`#T_table_level1_${col}`);
+                const link = th.find('a.software_header');
+                const text = link.text().trim();
+                if (text === software) {
+                    software_headers.push(th.attr('id'));
+                }
+            });
+
+            // Hide/Show the software headers
+            software_headers.forEach(function (header) {
+                if (is_checked){
+                    $('#' + header).show();
+                } else {
+                    $('#' + header).hide();
+                }
+            });
+
+            // Hide the data cells
+            const filtered_ids = matching_ids.filter(id => {
+                return updated_cols.some(col => id.endsWith(col));
+            });
+            filtered_ids.forEach(function (id) {
+                if (is_checked){
+                    $('#' + id).show();
+                } else {
+                    $('#' + id).hide();
+                }
+            });
+
+            // Adjust the column width of the cost function cell
+            var width = _get_cost_func_header_span(cost_func);
+            cost_function_header.attr('colspan', width);
+            
+        }         
+    });
 
     // Get all the minimizers names for a software
     const minimizer_names = _get_minimizer_names(software);
     minimizer_names.forEach(function (minimizer) {
-        // Call toggle_minimizer for each minimizer
-        toggle_minimizer(software, minimizer, independent_call = false);
-
         // Set the minimizer checkboxes
         var minimizer_checkboxes = $(`input[type="checkbox"][value="${minimizer}"]`)
         if (is_checked) {
@@ -180,14 +331,8 @@ function toggle_software(software) {
 * cost function dropdown menu.
 * @param   {String} cost_func   The name of the cost function.
 */
-function toggle_cost_function(cost_func) {
-    var cost_function_header = $('th a.cost_function_header').filter(function () {
-        return $(this).text().trim().toLowerCase() === cost_func;
-    }).parent();
-    
-    const is_checked = $(`input[type="checkbox"][value="${cost_func}"]`).is(':checked');
-
-    // Get the matching cell ids 
+function _get_all_data_cell_ids(cost_func) {
+    // Get the matching cell ids and the column numbers
     const matching_ids = [];
     const cols = [];
     $('td').each(function () {
@@ -200,35 +345,117 @@ function toggle_cost_function(cost_func) {
             cols.push(col_id)  
         }
     });
+    return [matching_ids, [...new Set(cols)]]
+}
 
+/**
+* Handles the case when a cost function is hidden or selected from the
+* cost function dropdown menu.
+* @param   {String} cost_func   The name of the cost function.
+* @param   {String} minimizer   The name of the minimizer.
+* @param   {String} software    The name of the software.
+*/
+function _get_minimizer_data_cell_ids(cost_func, minimizer, software) {
+    if (minimizer.includes(':')) {
+        // minimizer name will be shortened from 'lm-scipy: j:best_available' to 'lm-scipy'
+        minimizer = minimizer.split(':')[0].trim();
+    }
+    software = software.replace('-', '_');
+    var search_text = `a[href*="_${cost_func}_${minimizer}_[${software}"]`;
+    // Get the matching cell ids and the column numbers
+    const matching_ids = [];
+    $('td').each(function () {
+        const anchor = $(this).find(search_text);
+        if (anchor.length > 0) {
+            var id = $(this).attr('id');
+            matching_ids.push(id);  
+        }
+    });
+    return matching_ids
+}
+
+/**
+* Handles the case when a cost function is hidden or selected from the
+* cost function dropdown menu.
+* @param   {String} cost_func   The name of the cost function.
+*/
+function toggle_cost_function(cost_func) {
+    var cost_function_header = $('th a.cost_function_header').filter(function () {
+        return $(this).text().trim().toLowerCase() === cost_func;
+    }).parent();
+    const [matching_ids, cols] = _get_all_data_cell_ids(cost_func)
+    
     // Hide the cost function header names
+    const is_checked = $(`input[type="checkbox"][value="${cost_func}"]`).is(':checked');
     if (is_checked){
+        // Show cost function header
         cost_function_header.show();
+    
+        // Get software names
+        const software_names = _get_software_names()
+        // Iterate over the softwares
+        software_names.forEach(function (software) {
+
+            const is_software_checked = $(`input[type="checkbox"][value="${software}"]`).is(':checked') || $(`input[type="checkbox"][value="${software}"]`).is(':disabled');
+
+            if (is_software_checked){
+                // Show software header
+                const software_header = $('th a.software_header').filter(function () {
+                    const name = $(this).text().trim() === software;
+                    const thId = $(this).parent().attr('id');
+                    const colMatch = thId.match(/col\d+$/);
+                    const col = colMatch ? colMatch[0] : null;
+                    return name && cols.includes(col);
+                }).parent();
+                software_header.show();
+
+                // Get minimizer names
+                const minimizer_names = _get_minimizer_names(software)
+                // Iterate over the minimizers
+                minimizer_names.forEach(function (minimizer){
+                    var is_minimizer_checked = $(`input[type="checkbox"][value="${minimizer}"]`).is(':checked');
+
+                    if (is_minimizer_checked){
+                        // Show minimizer header
+                        const minimizer_header = $('th a.minimizer_header').filter(function () {
+                            const name = $(this).text().trim() === minimizer;
+                            const thId = $(this).parent().attr('id');
+                            const colMatch = thId.match(/col\d+$/);
+                            const col = colMatch ? colMatch[0] : null;
+                            return name && cols.includes(col);
+                        }).parent();
+                        minimizer_header.show();
+
+                        // Get the data cell ids of the minimizer
+                        const matching_minimizer_ids = _get_minimizer_data_cell_ids(cost_func, minimizer, software)
+                        matching_minimizer_ids.forEach(function (id) {
+                            // Show data cells
+                            $('#' + id).show();
+                        });
+                    } 
+                })
+            }
+        });
+        
     } else {
+        // Hide cost function header
         cost_function_header.hide();
+        cols.forEach(function (id) {
+            // Hide problem headers
+            $(`#T_table_level1_${id}`).hide(); 
+            // Hide minimizer headers
+            $(`#T_table_level2_${id}`).hide(); 
+        });
+        matching_ids.forEach(function (id) {
+            // Hide data cells
+            $('#' + id).hide();
+        });
     }
 
-    // Hide the problem and minimizer names
-    cols.forEach(function (id) {
-        const problem_th = $(`#T_table_level1_${id}`);
-        const minimizer_th = $(`#T_table_level2_${id}`);
-        if (is_checked){
-            problem_th.show();
-            minimizer_th.show();
-        } else {
-            problem_th.hide();
-            minimizer_th.hide();
-        }
-    });
+    // Adjust the column width of the cost function cell
+    var width = _get_cost_func_header_span(cost_func);
+    cost_function_header.attr('colspan', width);
 
-    // Hide the data cells
-    matching_ids.forEach(function (id) {
-        if (is_checked){
-            $('#' + id).show();
-        } else {
-            $('#' + id).hide();
-        }
-    });
 }
 
 /**

--- a/fitbenchmarking/templates/js/table.js
+++ b/fitbenchmarking/templates/js/table.js
@@ -11,14 +11,14 @@ function _find_element_from_text(class_name, search_text) {
 /**
 * Adjusts the span of a column header that encompasses a number of sub-headers.
 * @param   {jQuery Object} header   A collection of DOM elements representing column headers with a span.
-* @param   {bool} increment         True if the column span should be incremented. Otherwise it is decremented.
+* @param   {bool} decrement         True if the column span should be decremented. Otherwise it is incremented.
 */
-function _adjust_colspan(header, increment) {
+function _adjust_colspan(header, decrement) {
     var colspan = parseInt(header.attr('colspan'));
     if (isNaN(colspan)) {
-        var new_colspan = increment ? 1 : 0;
+        var new_colspan = decrement ? 0 : 1;
     } else {
-        var new_colspan = increment ? colspan + 1 : colspan - 1;
+        var new_colspan = decrement ? colspan - 1 : colspan + 1;
         header.attr('colspan', new_colspan);
     }
 
@@ -50,22 +50,74 @@ function toggle_minimizer(software, minimizer) {
     var minimizer_text = _find_element_from_text("a.minimizer_header", minimizer);
     var minimizer_header = minimizer_text.parent();
 
+    const is_minimizer_checked = $(`input[type="checkbox"][value="${minimizer}"]`).is(':checked');
+    const is_software_checked = $(`input[type="checkbox"][value="${software}"]`).is(':checked');
+    const hide = !is_software_checked || !is_minimizer_checked
+
     // Toggle the minimizer header
-    minimizer_header.toggle();
+    if (hide) {
+        minimizer_header.hide();
+    } else {
+        minimizer_header.show();
+    }
 
-    // Decrement or increment the column span of the cost function and software header
-    var is_visible = minimizer_header.is(":visible");
-
-    _adjust_colspan(cost_function_header, is_visible);
-    _adjust_colspan(software_header, is_visible);
+    _adjust_colspan(cost_function_header, hide);
+    _adjust_colspan(software_header, hide);
 
     // Toggle the data cells in a column
     var table_id = software_header.parent().parent().parent().attr("id");
 
     minimizer_text.each(function () {
         var column_num = parseInt($(this).attr('col')) + 3;
-        $("#" + table_id + " tr > td:nth-child(" + column_num + ")").toggle();
+        if (hide) {
+            $("#" + table_id + " tr > td:nth-child(" + column_num + ")").hide();
+        } else {
+            $("#" + table_id + " tr > td:nth-child(" + column_num + ")").show();
+        }
     });
+}
+
+
+function toggle_software(software) {
+    var software_header = _find_element_from_text("a.software_header", software).parent();
+    const is_checked = $(`input[type="checkbox"][value="${software}"]`).is(':checked');
+
+    // Toggle the software header
+    if (is_checked) {
+        software_header.show();
+    } else {
+        software_header.hide();
+    }
+    
+    // Extract the minimizer names associated with the software
+    const minimizer_names = [];
+    $(`a.minimizer_header[data-software="${software}"]`).each(function () {
+        minimizer_names.push($(this).text().trim());
+    });
+    const unique_minimizer_names = [...new Set(minimizer_names)];
+
+    // Call toggle_minimizer for each minimizer name
+    unique_minimizer_names.forEach(function (minimizer) {
+        toggle_minimizer(software, minimizer);
+
+        // Find the <li> that wraps the checkbox
+        const onclickStr = `toggle_minimizer('${software}', '${minimizer}')`;
+        const checkboxLi = $(`input[type="checkbox"][onclick="${onclickStr}"]`).closest('li');
+
+        // Show or hide based on is_checked
+        if (is_checked) {
+            checkboxLi.show();
+        } else {
+            checkboxLi.hide();
+        }
+    });
+}
+
+function toggle_cost_function(cost_func) {
+    var cost_function_header = $("a.cost_function_header").parent();
+
+// pass for now
+
 }
 
 /**

--- a/fitbenchmarking/templates/js/table.js
+++ b/fitbenchmarking/templates/js/table.js
@@ -175,11 +175,60 @@ function toggle_software(software) {
     });
 }
 
+/**
+* Handles the case when a cost function is hidden or selected from the
+* cost function dropdown menu.
+* @param   {String} cost_func   The name of the cost function.
+*/
 function toggle_cost_function(cost_func) {
-    var cost_function_header = $("a.cost_function_header").parent();
+    var cost_function_header = $('th a.cost_function_header').filter(function () {
+        return $(this).text().trim().toLowerCase() === cost_func;
+    }).parent();
+    
+    const is_checked = $(`input[type="checkbox"][value="${cost_func}"]`).is(':checked');
 
-// pass for now
+    // Get the matching cell ids 
+    const matching_ids = [];
+    const cols = [];
+    $('td').each(function () {
+        const anchor = $(this).find(`a[href*="_${cost_func}"]`);
+        if (anchor.length > 0) {
+            var id = $(this).attr('id');
+            matching_ids.push(id);
+            const match = id.match(/col\d+/);
+            const col_id = match ? match[0] : null;
+            cols.push(col_id)  
+        }
+    });
 
+    // Hide the cost function header names
+    if (is_checked){
+        cost_function_header.show();
+    } else {
+        cost_function_header.hide();
+    }
+
+    // Hide the problem and minimizer names
+    cols.forEach(function (id) {
+        const problem_th = $(`#T_table_level1_${id}`);
+        const minimizer_th = $(`#T_table_level2_${id}`);
+        if (is_checked){
+            problem_th.show();
+            minimizer_th.show();
+        } else {
+            problem_th.hide();
+            minimizer_th.hide();
+        }
+    });
+
+    // Hide the data cells
+    matching_ids.forEach(function (id) {
+        if (is_checked){
+            $('#' + id).show();
+        } else {
+            $('#' + id).hide();
+        }
+    });
 }
 
 /**

--- a/fitbenchmarking/templates/table_template.html
+++ b/fitbenchmarking/templates/table_template.html
@@ -50,7 +50,17 @@
                         <center>
                             <div>
                                 {{ problem_dropdown }}
-                                {{ minimizer_dropdown }}
+                                {% if has_multiple_costfuncs %}
+                                    {{ costfunc_dropdown }}
+                                {% endif %}  
+                                {% if has_multiple_softwares %}
+                                    {{ software_dropdown }}
+                                {% endif %}
+                                {% if has_multiple_minimizers %}
+                                    {{ minimizer_dropdown }}
+                                {% endif %}
+                            </div>
+                            <div>
                                 {{ runtime_dropdown }}
                                 {{ probsize_checkbox }}
                             </div>

--- a/fitbenchmarking/templates/table_template.html
+++ b/fitbenchmarking/templates/table_template.html
@@ -50,15 +50,9 @@
                         <center>
                             <div>
                                 {{ problem_dropdown }}
-                                {% if has_multiple_costfuncs %}
-                                    {{ costfunc_dropdown }}
-                                {% endif %}  
-                                {% if has_multiple_softwares %}
-                                    {{ software_dropdown }}
-                                {% endif %}
-                                {% if has_multiple_minimizers %}
-                                    {{ minimizer_dropdown }}
-                                {% endif %}
+                                {{ costfunc_dropdown }}
+                                {{ software_dropdown }}
+                                {{ minimizer_dropdown }}
                             </div>
                             <div class="checkbox-row">
                                 {{ runtime_dropdown }}

--- a/fitbenchmarking/templates/table_template.html
+++ b/fitbenchmarking/templates/table_template.html
@@ -60,7 +60,7 @@
                                     {{ minimizer_dropdown }}
                                 {% endif %}
                             </div>
-                            <div>
+                            <div class="checkbox-row">
                                 {{ runtime_dropdown }}
                                 {{ probsize_checkbox }}
                             </div>


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #993 


https://github.com/user-attachments/assets/ba9686c2-231c-4f46-ae97-2a9273b47f09


<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Create an options file with the following content. Name the file `tmp.ini`. And run `fitbenchmarking -o tmp.ini`.
```
[FITTING]

software: bumps
          scipy
          scipy_ls

cost_func_type: weighted_nlls
                nlls

num_runs: 1
max_runtime: 600

[MINIMIZERS]

bumps: lm-bumps
       scipy-leastsq

scipy: Powell
       CG
       TNC

scipy_ls: lm-scipy
```
2. Verify new dropdown menus are visible for all the table.
      <img width="726" alt="image" src="https://github.com/user-attachments/assets/8ac67b8b-9fd5-4608-a8d4-c4cdd89cda16" />
3. Uncheck options from the new menus and verify that everything is updated as expected.


## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
      #1478
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

