### PR TITLE
Added ability to enable/disable error bars on fit plot

### DIFF
--- a/fitbenchmarking/results_processing/plots.py
+++ b/fitbenchmarking/results_processing/plots.py
@@ -192,7 +192,7 @@ class Plot:
                 title=self.result.name, legend=self._legend_style
             )
             self._update_to_logscale_if_needed(fig, self.result)
-
+            self._add_menu_buttons(fig)
             htmlfile = (
                 f"{minimizer}_fit_for_{self.result.costfun_tag}"
                 f"_{self.result.sanitised_name}.html"
@@ -983,6 +983,40 @@ class Plot:
             fig.update_xaxes(type="log")
         if result.plot_scale in ["loglog", "logy"]:
             fig.update_yaxes(type="log")
+        return fig
+
+    @staticmethod
+    def _add_menu_buttons(fig) -> go.Figure:
+        """
+        Adds an interactible menu to the plot
+
+        :param fig: The plotly figure to update the axis for
+        :type fig: plotly.graph_objects.Figure
+
+        :return: Updated plot
+        :rtype: plotly.graph_objects.Figure
+        """
+        fig.update_layout(
+            updatemenus=[
+                {
+                    "type": "buttons",
+                    "direction": "down",
+                    "showactive": False,
+                    "x": 1.25,
+                    "y": 1.15,
+                    "xanchor": "right",
+                    "yanchor": "top",
+                    "buttons": [
+                        {
+                            "label": "Toggle error bars",
+                            "method": "restyle",
+                            "args": [{"error_y.visible": [True]}, [0]],
+                            "args2": [{"error_y.visible": [False]}, [0]],
+                        }
+                    ],
+                }
+            ]
+        )
         return fig
 
     @staticmethod

--- a/fitbenchmarking/results_processing/plots.py
+++ b/fitbenchmarking/results_processing/plots.py
@@ -988,7 +988,7 @@ class Plot:
     @staticmethod
     def _add_menu_buttons(fig) -> go.Figure:
         """
-        Adds an interactible menu to the plot
+        Adds an interactible button to the plot, to toggle error bars
 
         :param fig: The plotly figure to update the axis for
         :type fig: plotly.graph_objects.Figure

--- a/fitbenchmarking/results_processing/tests/test_plots.py
+++ b/fitbenchmarking/results_processing/tests/test_plots.py
@@ -153,8 +153,8 @@ class PlotTests(unittest.TestCase):
 
     def test_plotly_fit_create_files(self):
         """
-        Test that plotly_fit creates a file and errorbars are
-        added to the plot.
+        Test that plotly_fit creates a file with the expected file name, error
+        bars and interactible buttons.
         """
         file_names = self.plot.plotly_fit(
             self.df[("Fake_Test_Data", "prob_1")]

--- a/fitbenchmarking/results_processing/tests/test_plots.py
+++ b/fitbenchmarking/results_processing/tests/test_plots.py
@@ -59,6 +59,15 @@ def find_error_bar_count(path):
     return html_content.count("error_y")
 
 
+def find_error_bar_toggle(path):
+    """
+    Reads html file checks if the Toggle error button is there
+    """
+    with open(path, encoding="utf-8") as file:
+        html_content = file.read()
+    return "Toggle error bars" in html_content
+
+
 class PlotTests(unittest.TestCase):
     """
     Test the plot object is correct.
@@ -163,7 +172,8 @@ class PlotTests(unittest.TestCase):
             )
             path = os.path.join(self.figures_dir, file_names[file_name_prefix])
             self.assertTrue(os.path.exists(path))
-            self.assertEqual(find_error_bar_count(path), 2)
+            self.assertEqual(find_error_bar_count(path), 4)
+            self.assertTrue(find_error_bar_toggle(path))
 
     @mock.patch(
         "fitbenchmarking.results_processing.plots.Plot._check_data_len"

--- a/fitbenchmarking/results_processing/tests/test_plots.py
+++ b/fitbenchmarking/results_processing/tests/test_plots.py
@@ -61,7 +61,7 @@ def find_error_bar_count(path):
 
 def find_error_bar_toggle(path):
     """
-    Reads html file checks if the Toggle error button is there
+    Reads html file and checks that the Toggle error button is there
     """
     with open(path, encoding="utf-8") as file:
         html_content = file.read()


### PR DESCRIPTION
A new button should appear on all fit plots to disable or enable the error bars on the plot

<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1587 

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Open any fitting report
2. Observe that "toggle error bars" button is present
3. Clicking should only disable/enable error bars for the "Data" plot (i.e. not for the fitted lines)
<img width="1059" height="591" alt="image" src="https://github.com/user-attachments/assets/445b841d-cf8e-432f-a5ff-555362aba983" />

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

