### PR TITLE
Fixed failing Mantid Multifit regression tests

### DIFF
--- a/fitbenchmarking/controllers/tests/test_mantid_controller.py
+++ b/fitbenchmarking/controllers/tests/test_mantid_controller.py
@@ -133,18 +133,11 @@ class TestMantidController(TestCase):
         [
             (
                 Path("multifit_set") / "multifit.txt",
-                (
-                    "name=LinearBackground,A0=0,A1=0;"
-                    " name=GausOsc,A=0.2,Sigma=0.2,Frequency=1,Phi=0"
-                ),
-                True,
+                ("name=LinearBackground,A0=0,A1=0"),
+                False,
                 [
-                    "f0.A0",
-                    "f0.A1",
-                    "f1.A",
-                    "f1.Sigma",
-                    "f1.Frequency",
-                    "f1.Phi",
+                    "A0",
+                    "A1",
                 ],
                 2,
                 True,
@@ -526,11 +519,11 @@ class TestMantidController(TestCase):
             (
                 "Damped GaussNewton",
                 True,
-                2,
+                0,
                 False,
                 [
-                    [0.0, 0.0, 0.2, 0.2, 1.0, 0.0],
-                    [0.0, 0.0, 0.2, 0.2, 1.0, 0.0],
+                    [5.465904281234018, 3.306399846283738],
+                    [11.652541583443453, 3.306399846283738],
                 ],
             ),
             (
@@ -545,14 +538,7 @@ class TestMantidController(TestCase):
                 False,
                 1,
                 True,
-                [
-                    9.992968384080259,
-                    2.0019412967622623,
-                    -6.498087151207797,
-                    2.432705755554191,
-                    -0.0021839598697108633,
-                    -1.5707513496110153,
-                ],
+                [10.00867422891315, 1.9999803827377036],
             ),
         ]
     )

--- a/fitbenchmarking/systests/linux_expected_results/multifit.csv
+++ b/fitbenchmarking/systests/linux_expected_results/multifit.csv
@@ -1,4 +1,4 @@
 ,,mantid,mantid
 ,,Levenberg-Marquardt: j:scipy 2-point,Levenberg-Marquardt: j:scipy 3-point
-"Basic MultiFit, Dataset 1","6 params, 18 points",8.231 (1),8.231 (1)
-"Basic MultiFit, Dataset 2","6 params, 18 points",15.19 (1),15.19 (1)
+"Basic MultiFit, Dataset 1","2 params, 18 points",11.97 (1)[2],11.97 (1)[2]
+"Basic MultiFit, Dataset 2","2 params, 18 points",15.52 (1)[2],15.52 (1)[2]

--- a/fitbenchmarking/test_files/multifit_set/multifit.txt
+++ b/fitbenchmarking/test_files/multifit_set/multifit.txt
@@ -1,7 +1,7 @@
 # FitBenchmark Problem
 software = 'Mantid'
 name = 'Basic MultiFit'
-description = 'This is meaningless data designed to test the parser works.'
+description = 'This was copied from the Mantid Fit documentation to test that MultiFit worked in FitBenchmarking'
 input_file = ['multifit1.txt','multifit2.txt']
-function = 'name=LinearBackground,A0=0,A1=0; name=GausOsc,A=0.2,Sigma=0.2,Frequency=1,Phi=0'
-ties = ['f0.A1']
+function = 'name=LinearBackground,A0=0,A1=0'
+ties = ['A1']


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Fixes #1627 

<!---

Describe your changes and why you're making them.

-->

The basic multifit problem used in the regression tests has been changed to match the basic multifit problem in the `examples` directory (removing the GaussOsc model from the function string). 


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1. Check that Mantid system tests now pass
2.
3.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

