### PR TITLE
Fixed bugs with non-Mantid Multifit implementation

### DIFF
--- a/docs/source/users/problem_definition_files/mantid.rst
+++ b/docs/source/users/problem_definition_files/mantid.rst
@@ -155,6 +155,18 @@ against the data in the corresponding input file.
    the status "Validation of the provided options failed".
 
 .. warning::
+   :ref:`Hessians <hessian_option>` are not available for MultiFit problems
+   yet. The ``hes_method`` option should be left as ``default``, otherwise
+   the run is reported as a failed run with the status "Validation of the
+   provided options failed".
+
+.. warning::
+   Only the least squares cost functions (see :ref:`cost_func`) are
+   available for MultiFit problems with softwares other than Mantid.
+   Selecting any other cost function is reported as a failed run with the
+   status "Validation of the provided options failed".
+
+.. warning::
    MCMC minimizers (e.g. ``FABADA``, ``dream``, ``emcee`` and
    ``paraDram_sampler``) are not available for MultiFit problems yet.
    Selecting one for a MultiFit problem is reported as a failed run with

--- a/fitbenchmarking/controllers/base_controller.py
+++ b/fitbenchmarking/controllers/base_controller.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from scipy.optimize import curve_fit
 
+from fitbenchmarking.cost_func.nlls_base_cost_func import BaseNLLSCostFunc
 from fitbenchmarking.jacobian.analytic_jacobian import Analytic
 from fitbenchmarking.utils.exceptions import (
     ControllerAttributeError,
@@ -249,78 +250,95 @@ class Controller:
 
     def multifit_init(self):
         """
-        Construct parameter array for multifit problems.
+        Construct the combined parameter array for multifit problems.
+
+        Each dataset gets its own copy of every parameter, prefixed with
+        ``d<i>.``, apart from the tied parameters which are shared by all
+        the datasets and are prefixed with ``shared.``. Starting values
+        and bounds are expanded to match. This is undone by
+        multifit_cleanup once the fit has finished.
         """
+        # Save the problem's starting values and bounds so that
+        # multifit_cleanup can restore them, and so that
+        # this can be run again for the next minimizer.
+        self._save_starting_values = self.starting_values
+        self._save_value_ranges = self.value_ranges
 
-        # save starting values for an individual dataset for fitting report
-        self._save_starting_values_per_dataset = self.starting_values
-
-        params = self.starting_values[0]
+        par_names = list(self.starting_values[0])
         shared_params = self.problem.additional_info["ties"]
-        param_dict = {}
 
         # value_ranges is a per-parameter list of (lb, ub) tuples aligned
         # with the original parameter order. When bounds are set, expand
         # them alongside the param array so they stay aligned with the new
         # (shared./d<i>.) parameters. The original per-parameter bounds
         # are restored in multifit_cleanup.
-        self._save_value_ranges = self.value_ranges
-        bounds = self.value_ranges or [None] * len(params)
+        bounds = self.value_ranges or [None] * len(par_names)
+        combined_par_names = []
         expanded_value_ranges = []
 
-        for (k, v), vr in zip(params.items(), bounds):
-            if k in shared_params:
-                param_dict[f"shared.{k}"] = v
+        for name, vr in zip(par_names, bounds):
+            if name in shared_params:
+                combined_par_names.append(f"shared.{name}")
                 expanded_value_ranges.append(vr)
             else:
                 for i in range(self._dataset_count):
-                    param_dict[f"d{i}.{k}"] = v
+                    combined_par_names.append(f"d{i}.{name}")
                     expanded_value_ranges.append(vr)
 
         if self.value_ranges is not None:
             self.value_ranges = expanded_value_ranges
 
-        self.starting_values = [param_dict]
-        self.par_names = list(param_dict.keys())
-        self.problem.multifit_param_names = self.par_names
+        self.starting_values = [
+            {
+                combined: values[combined.split(".", 1)[1]]
+                for combined in combined_par_names
+            }
+            for values in self._save_starting_values
+        ]
+        self.par_names = combined_par_names
+        self.problem.multifit_param_names = combined_par_names
 
     def multifit_cleanup(self):
         """
-        Map the final parameters to a list of lists, with each sublist
-        containing the final parameters for each dataset.
+        Undo multifit_init. The final parameters are mapped to a list of
+        lists, with each sublist containing the final parameters for one
+        dataset, and the per dataset parameter names, starting values and
+        bounds are restored for reporting.
+
         This also runs when a fit has failed, so it must cope with the
-        final parameters not having been set.
+        final parameters not having been set, and it must be safe to call
+        when multifit_init has not run or when it has already run once.
         """
         combined_par_names = self.problem.multifit_param_names
+        if combined_par_names is None:
+            return
 
         # create a list of lists of final params for each dataset
         if self.final_params is not None and not any(
             p is None for p in self.final_params
         ):
             param_dict = dict(zip(combined_par_names, self.final_params))
-            lists_of_final_params = [[] for _ in range(self._dataset_count)]
+            self.final_params = [
+                [
+                    v
+                    for k, v in param_dict.items()
+                    if k.startswith((f"d{d}.", "shared."))
+                ]
+                for d in range(self._dataset_count)
+            ]
 
-            for d in range(self._dataset_count):
-                for k, v in param_dict.items():
-                    if k.startswith((f"d{d}.", "shared.")):
-                        lists_of_final_params[d].append(v)
-
-            self.final_params = lists_of_final_params
-
-        # remove all the d0, d1, ... and shared. prefixes
-        # from the parameter names
-        single_dataset_param_names = [
-            name.split(".", 1)[1] for name in combined_par_names
-        ]
-
-        self.par_names = list(dict.fromkeys(single_dataset_param_names))
-        self.initial_params = list(
-            self._save_starting_values_per_dataset[0].values()
-        )
-
-        # restore the original per-parameter bounds so that the post-fit
-        # check_bounds_respected lines up with final_params
+        # Restore the per dataset state so that results are reported
+        # against the problem's own parameters, and clear
+        # multifit_param_names so that single dataset evaluations made
+        # from here on (e.g. by eval_chisq) are not mistaken for the
+        # combined problem.
+        self.starting_values = self._save_starting_values
         self.value_ranges = self._save_value_ranges
+        self.par_names = list(self.starting_values[0])
+        self.initial_params = list(
+            self.starting_values[self.parameter_set or 0].values()
+        )
+        self.problem.multifit_param_names = None
 
     def prepare(self, skip_setup=False):
         """
@@ -491,11 +509,23 @@ class Controller:
     def _validate_multifit(self):
         """
         Validates that the selected options are supported for MultiFit
-        problems. Analytic Jacobians and MCMC minimizers are not
-        available for MultiFit yet, so an exception is raised for these.
+        problems. Analytic Jacobians, Hessians, MCMC minimizers and non
+        least squares cost functions are not available for MultiFit yet,
+        so an exception is raised for these.
         """
         if not self.problem.multifit:
             return
+
+        # Only the least squares cost functions are set up to combine
+        # datasets. Mantid combines them itself, so it is not affected.
+        if self.software != "mantid" and not isinstance(
+            self.cost_func, BaseNLLSCostFunc
+        ):
+            raise IncompatibleMultifitError(
+                f"The '{self.cost_func.__class__.__name__}' cost function "
+                "is not available for MultiFit problems yet. Please select "
+                "a non-linear least squares cost function."
+            )
 
         jacobian = self.cost_func.jacobian
         # 'best_available' wraps an Analytic jacobian when the problem
@@ -507,6 +537,15 @@ class Controller:
                 "MultiFit problems yet, as it uses the analytic Jacobian "
                 "of the problem. Please select a numerical Jacobian "
                 "method."
+            )
+
+        # The Hessian methods evaluate the model one dataset at a time,
+        # so they cannot size their output for the combined problem.
+        if self.cost_func.hessian is not None:
+            raise IncompatibleMultifitError(
+                f"The '{self.cost_func.hessian.name()}' Hessian is not "
+                "available for MultiFit problems yet. Please set the "
+                "'hes_method' option to 'default'."
             )
 
         if self.minimizer in self.algorithm_check.get("MCMC", []):

--- a/fitbenchmarking/controllers/bumps_controller.py
+++ b/fitbenchmarking/controllers/bumps_controller.py
@@ -75,7 +75,12 @@ class BumpsController(Controller):
         # Bumps fails with the *args notation
         param_name_str = ", ".join(self._param_names)
         wrapper = f"def fitFunction(x, {param_name_str}):\n"
-        wrapper += f"    return func([{param_name_str}], x=x)"
+        if self.problem.multifit:
+            # The residuals of every dataset are evaluated together from
+            # the combined params, so there is no single x to pass in.
+            wrapper += f"    return func([{param_name_str}])"
+        else:
+            wrapper += f"    return func([{param_name_str}], x=x)"
 
         # Remove any function attribute. BinWidth is the only attribute in all
         # FitBenchmark (Mantid) problems.
@@ -98,10 +103,17 @@ class BumpsController(Controller):
             exec_dict = {"func": self.cost_func.eval_r}
             exec(wrapper, exec_dict)
             model = exec_dict["fitFunction"]
-            zero_y = np.zeros(np.shape(self.data_y))
-            func_wrapper = Curve(
-                fn=model, x=self.data_x, y=zero_y, **param_dict
-            )
+            if self.problem.multifit:
+                # Curve only feeds x to the model and compares its output
+                # against y, so use a flat placeholder x and a zero y
+                # covering the points of every dataset.
+                n_points = sum(len(d) for d in self.data_y)
+                curve_x = np.arange(n_points)
+                zero_y = np.zeros(n_points)
+            else:
+                curve_x = self.data_x
+                zero_y = np.zeros(np.shape(self.data_y))
+            func_wrapper = Curve(fn=model, x=curve_x, y=zero_y, **param_dict)
 
         # Set a range for each parameter
         for ind, name in enumerate(self._param_names):

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -21,6 +21,7 @@ from fitbenchmarking.controllers.controller_factory import ControllerFactory
 from fitbenchmarking.cost_func.loglike_nlls_cost_func import (
     LoglikeNLLSCostFunc,
 )
+from fitbenchmarking.cost_func.poisson_cost_func import PoissonCostFunc
 from fitbenchmarking.cost_func.weighted_nlls_cost_func import (
     WeightedNLLSCostFunc,
 )
@@ -614,6 +615,51 @@ class BaseControllerTests(TestCase):
         controller.check_bounds_respected()
 
         assert controller.flag == 5
+
+    def _poisson_controller(self):
+        """
+        Create a controller with a cost function which is not a least
+        squares one, ready for validate to be called on.
+
+        :return: A controller using the Poisson cost function
+        :rtype: DummyController
+        """
+        cost_func = PoissonCostFunc(self.problem)
+        cost_func.jacobian = Scipy(self.problem)
+        cost_func.jacobian.method = "2-point"
+        return DummyController(cost_func)
+
+    def test_validate_multifit_non_least_squares_cost_func(self):
+        """
+        Test that a cost function which is not a least squares one is
+        rejected in the multifit case
+        """
+        controller = self._poisson_controller()
+        controller.problem.multifit = True
+
+        with self.assertRaises(exceptions.IncompatibleMultifitError):
+            controller.validate()
+
+    def test_validate_multifit_non_least_squares_cost_func_mantid(self):
+        """
+        Test that a cost function which is not a least squares one is
+        accepted in the multifit case when the software is mantid, as
+        mantid combines the datasets itself
+        """
+        controller = self._poisson_controller()
+        controller.problem.multifit = True
+        controller._software = "mantid"
+
+        controller.validate()
+
+    def test_validate_multifit_non_least_squares_cost_func_not_multifit(self):
+        """
+        Test that a cost function which is not a least squares one is
+        accepted when the problem is not a multifit problem
+        """
+        controller = self._poisson_controller()
+
+        controller.validate()
 
     def test_validate_multifit_analytic_jacobian(self):
         """

--- a/fitbenchmarking/controllers/tests/test_controllers.py
+++ b/fitbenchmarking/controllers/tests/test_controllers.py
@@ -468,9 +468,7 @@ class BaseControllerTests(TestCase):
         expected = {"d0.A0": 0.0, "d1.A0": 0.0, "shared.A1": 1.0}
         assert controller.starting_values == [expected]
         assert controller.par_names == list(expected.keys())
-        assert controller._save_starting_values_per_dataset == [
-            {"A0": 0.0, "A1": 1.0}
-        ]
+        assert controller._save_starting_values == [{"A0": 0.0, "A1": 1.0}]
         # The free parameter's bounds are repeated per dataset and the tied
         # parameter's bounds appear once, matching the expanded param order.
         assert controller.value_ranges == [(0, 5), (0, 5), (10, 20)]
@@ -502,7 +500,7 @@ class BaseControllerTests(TestCase):
         """
         controller = DummyController(self.cost_func)
         controller._dataset_count = 2
-        controller._save_starting_values_per_dataset = [{"A0": 0.0, "A1": 1.0}]
+        controller._save_starting_values = [{"A0": 0.0, "A1": 1.0}]
         controller.par_names = ["d0.A0", "d1.A0", "shared.A1"]
         controller.problem.multifit_param_names = controller.par_names
         # The expanded bounds (as built by multifit_init) and the original
@@ -652,6 +650,37 @@ class BaseControllerTests(TestCase):
         controller.problem.jacobian = lambda x, p: np.array([x])
         controller.cost_func.jacobian = Analytic(controller.problem)
         controller.cost_func.jacobian.method = "default"
+
+        controller.validate()
+
+    def test_validate_multifit_hessian(self):
+        """
+        Test that a Hessian is rejected in the multifit case
+        """
+        controller = DummyController(self.cost_func)
+        controller.problem.multifit = True
+        controller.cost_func.jacobian = Scipy(controller.problem)
+        controller.cost_func.jacobian.method = "2-point"
+        controller.cost_func.hessian = ScipyHessian(
+            controller.problem, controller.cost_func.jacobian
+        )
+        controller.cost_func.hessian.method = "2-point"
+
+        with self.assertRaises(exceptions.IncompatibleMultifitError):
+            controller.validate()
+
+    def test_validate_multifit_hessian_not_multifit(self):
+        """
+        Test that a Hessian is accepted when the problem is not a
+        multifit problem
+        """
+        controller = DummyController(self.cost_func)
+        controller.cost_func.jacobian = Scipy(controller.problem)
+        controller.cost_func.jacobian.method = "2-point"
+        controller.cost_func.hessian = ScipyHessian(
+            controller.problem, controller.cost_func.jacobian
+        )
+        controller.cost_func.hessian.method = "2-point"
 
         controller.validate()
 

--- a/fitbenchmarking/core/fitting_benchmarking.py
+++ b/fitbenchmarking/core/fitting_benchmarking.py
@@ -307,11 +307,6 @@ class Fit:
                     software=s
                 )
                 controller = controller_cls(cost_func=cost_func)
-                if (
-                    controller.problem.multifit
-                    and controller.software != "mantid"
-                ):
-                    controller.multifit_init()
 
             controller.parameter_set = self._start_values_index
 
@@ -566,8 +561,16 @@ class Fit:
         tracker = self._emissions_tracker
         tracker_stopped = False
 
+        # For multifit problems, Mantid combines the datasets itself,
+        # everything else needs the controller to do it
+        combine_datasets = (
+            controller.problem.multifit and controller.software != "mantid"
+        )
+
         try:
             with self._grabbed_output:
+                if combine_datasets:
+                    controller.multifit_init()
                 controller.validate()
                 controller.prepare()
                 if tracker:
@@ -582,10 +585,7 @@ class Fit:
                         num_runs, 1
                     )
                 controller.cleanup()
-                if (
-                    controller.problem.multifit
-                    and controller.software != "mantid"
-                ):
+                if combine_datasets:
                     controller.multifit_cleanup()
                 controller.check_attributes()
 
@@ -660,11 +660,12 @@ class Fit:
         if controller.flag in [3, 6, 7]:
             multi_fit = controller.problem.multifit
 
-            # The fit failed, so multifit_cleanup has not run yet. Running it
-            # here splits the combined problem back into its datasets, so
-            # that the parameter names, initial params and bounds are
-            # reported per dataset as they are for a successful fit.
-            if multi_fit and controller.software != "mantid":
+            # The fit failed, so multifit_cleanup may not have run yet.
+            # Running it here splits the combined problem back into its
+            # datasets, so that the parameter names, initial params and
+            # bounds are reported per dataset as they are for a successful
+            # fit. It is a no-op if it has already run.
+            if combine_datasets:
                 controller.multifit_cleanup()
 
             # A validation error is raised before the controller is prepared,

--- a/fitbenchmarking/cost_func/nlls_base_cost_func.py
+++ b/fitbenchmarking/cost_func/nlls_base_cost_func.py
@@ -2,14 +2,13 @@
 Implements the base non-linear least squares cost function
 """
 
-import re
 from abc import abstractmethod
 
+import numpy as np
 from numpy import dot, matmul
 
 from fitbenchmarking.cost_func.base_cost_func import CostFunc
-
-_MULTIFIT_PREFIX = re.compile(r"(d\d+|shared)\.")
+from fitbenchmarking.utils.exceptions import CostFuncError
 
 
 class BaseNLLSCostFunc(CostFunc):
@@ -59,6 +58,27 @@ class BaseNLLSCostFunc(CostFunc):
         """
         raise NotImplementedError
 
+    def _evaluating_combined_multifit(self, x) -> bool:
+        """
+        Check whether eval_r has been asked for the combined multifit
+        problem rather than for a single dataset.
+
+        The combined problem is being evaluated when the caller gives no
+        x data (minimizers call eval_r with the parameters only) or gives
+        the whole container of datasets. A single dataset's x values mean
+        the params belong to that dataset alone, which is the case when
+        eval_chisq scores each dataset in turn once the fit has finished.
+
+        :param x: The x data eval_r was called with, if any
+        :type x: numpy array, list of numpy arrays or None
+
+        :return: True if the combined problem should be evaluated
+        :rtype: bool
+        """
+        if not (self.problem.multifit and self.problem.multifit_param_names):
+            return False
+        return x is None or isinstance(x, (list, tuple)) or np.ndim(x) > 1
+
     def eval_r(self, params, **kwargs):
         """
         Calculates residuals used in Least-Squares problems.
@@ -71,51 +91,35 @@ class BaseNLLSCostFunc(CostFunc):
         :return: The residuals for the datapoints at the given parameters
         :rtype: np.array
         """
-        if (
-            self.problem.multifit
-            and self.problem.multifit_param_names is not None
-            and any(
-                _MULTIFIT_PREFIX.match(name)
-                for name in self.problem.multifit_param_names
+        if not self._evaluating_combined_multifit(kwargs.get("x")):
+            return self.eval_r_single_dataset(params, **kwargs)
+
+        par_names = self.problem.multifit_param_names
+        if len(params) != len(par_names):
+            raise CostFuncError(
+                "The number of parameters does not match the number of "
+                f"MultiFit parameters, len(params)={len(params)} and "
+                f"len(multifit_param_names)={len(par_names)}."
             )
-        ):
-            r = []
 
-            if kwargs.get("x") is not None:
-                # Within the multifit case, kwargs.get("x") will appear
-                # in different forms, depending on the function that is
-                # calling eval_r
-                if isinstance(kwargs.get("x")[0], list):
-                    dataset_count = len(kwargs.get("x"))
+        # Each dataset is evaluated with its own d<i>. params plus the
+        # shared. params, and the residuals are joined into one vector.
+        param_dict = dict(zip(par_names, params))
+        r = [
+            self.eval_r_single_dataset(
+                params=[
+                    v
+                    for k, v in param_dict.items()
+                    if k.startswith((f"d{d}.", "shared."))
+                ],
+                x=self.problem.data_x[d],
+                y=self.problem.data_y[d],
+                e=self.problem.data_e[d],
+            )
+            for d in range(len(self.problem.data_x))
+        ]
 
-                # kwargs.get("x") does not contain lists, then we
-                # assume we are currently dealing with a single dataset
-                else:
-                    dataset_count = 1
-
-            else:
-                dataset_count = len(self.problem.data_x)
-
-            param_dict = dict(zip(self.problem.multifit_param_names, params))
-            for d in range(dataset_count):
-                single_dataset_params = []
-                for k, v in param_dict.items():
-                    if k.startswith((f"d{d}.", "shared.")):
-                        single_dataset_params.append(v)
-
-                kwargs["x"] = self.problem.data_x[d]
-                kwargs["y"] = self.problem.data_y[d]
-                kwargs["e"] = self.problem.data_e[d]
-
-                r_single = self.eval_r_single_dataset(
-                    params=single_dataset_params, **kwargs
-                )
-
-                r.extend(r_single)
-        else:
-            r = self.eval_r_single_dataset(params, **kwargs)
-
-        return r
+        return np.concatenate(r)
 
     def eval_cost(self, params, **kwargs):
         """

--- a/fitbenchmarking/parsing/fitting_problem.py
+++ b/fitbenchmarking/parsing/fitting_problem.py
@@ -157,31 +157,25 @@ class FittingProblem:
         self.timer.check_elapsed_time()
         x = kwargs.get("x", self.data_x)
 
-        if isinstance(x, np.ndarray):
-            return self.function(x, *params)
-
-        # Multifit case
-        elif isinstance(x, list):
-            # Split params into list of lists
-            dataset_count = len(x)
+        # Multifit case: x holds the x values of every dataset and params
+        # holds the combined (shared./d<i>.) parameters, so split the
+        # params up and evaluate the function once per dataset.
+        if self.multifit and self.multifit_param_names and isinstance(x, list):
             param_dict = dict(zip(self.multifit_param_names, params))
-            lists_of_params = [[] for _ in range(dataset_count)]
-
-            for d in range(dataset_count):
-                for k, v in param_dict.items():
-                    if k.startswith((f"d{d}.", "shared.")):
-                        lists_of_params[d].append(v)
-
-            # Call self.function on each xi (and params for that xi)
             out = [
-                self.function(xi, *params)
-                for xi, params in zip(x, lists_of_params)
+                self.function(
+                    x_d,
+                    *[
+                        v
+                        for k, v in param_dict.items()
+                        if k.startswith((f"d{d}.", "shared."))
+                    ],
+                )
+                for d, x_d in enumerate(x)
             ]
-
             return np.concatenate(out)
 
-        else:
-            raise ValueError("x is neither an array nor a list")
+        return self.function(x, *params)
 
     @property
     def param_names(self):

--- a/fitbenchmarking/parsing/tests/test_fitting_problem.py
+++ b/fitbenchmarking/parsing/tests/test_fitting_problem.py
@@ -141,15 +141,15 @@ class TestFittingProblem(TestCase):
         expected = np.array([1006.0, 1007.0, 1110.0, 1120.0])
         self.assertTrue(np.allclose(eval_result, expected))
 
-    def test_eval_model_invalid_x_type(self):
+    def test_eval_model_list_x_without_multifit(self):
         """
-        Test that eval_model raises a ValueError when x is neither an
-        array nor a list
+        Test that a list of x values is passed straight to the function
+        when the problem is not multifit
         """
         fitting_problem = FittingProblem(self.options)
-        fitting_problem.function = lambda x, p1: x + p1
-        with self.assertRaises(ValueError):
-            fitting_problem.eval_model(x="not_valid", params=[5])
+        fitting_problem.function = lambda x, p1: np.array(x) + p1
+        eval_result = fitting_problem.eval_model(x=[1, 8, 11], params=[5])
+        self.assertTrue(all(eval_result == np.array([6, 13, 16])))
 
     def test_get_function_params(self):
         """

--- a/fitbenchmarking/systests/linux_expected_results/multifit.csv
+++ b/fitbenchmarking/systests/linux_expected_results/multifit.csv
@@ -1,4 +1,4 @@
 ,,bumps,dfo,lmfit,mantid,minuit,nlopt,scipy,scipy_leastsq,scipy_ls
 ,,lm-bumps,dfols,least_squares,Levenberg-Marquardt: j:best_available,migrad,LD_VAR1: j:best_available,Nelder-Mead,lm-leastsq: j:best_available,lm-scipy: j:best_available
-"Basic MultiFit, Dataset 1","2 params, 18 points",7.925e-07 (1),11.97 (1.51e+07),198.2 (2.501e+08),11.97 (1.51e+07)[2],11.97 (1.511e+07),45.64 (5.759e+07),71.54 (9.027e+07),11.97 (1.51e+07),11.97 (1.51e+07)
-"Basic MultiFit, Dataset 2","2 params, 18 points",106.2 (6.846),52.64 (3.392),197.9 (12.75),15.52 (1)[2],52.65 (3.393),45.64 (2.941),85.96 (5.539),52.64 (3.392),52.64 (3.392)
+"Basic MultiFit, Dataset 1","2 params, 18 points",11.97 (1),11.97 (1),198.2 (16.56),11.97 (1)[2],11.97 (1),45.64 (3.812),71.54 (5.977),11.97 (1),11.97 (1)
+"Basic MultiFit, Dataset 2","2 params, 18 points",15.52 (5.974),15.52 (5.974),365.4 (140.7),15.52 (5.974)[2],15.51 (5.973),144.7 (55.72),2.598 (1),15.52 (5.974),15.52 (5.974)

--- a/fitbenchmarking/systests/linux_expected_results/multifit.csv
+++ b/fitbenchmarking/systests/linux_expected_results/multifit.csv
@@ -1,4 +1,4 @@
 ,,bumps,dfo,lmfit,mantid,minuit,nlopt,scipy,scipy_leastsq,scipy_ls
 ,,lm-bumps,dfols,least_squares,Levenberg-Marquardt: j:best_available,migrad,LD_VAR1: j:best_available,Nelder-Mead,lm-leastsq: j:best_available,lm-scipy: j:best_available
-"Basic MultiFit, Dataset 1","2 params, 18 points",11.97 (1),11.97 (1),198.2 (16.56),11.97 (1)[2],11.97 (1),45.64 (3.812),71.54 (5.977),11.97 (1),11.97 (1)
-"Basic MultiFit, Dataset 2","2 params, 18 points",15.52 (5.974),15.52 (5.974),365.4 (140.7),15.52 (5.974)[2],15.51 (5.973),144.7 (55.72),2.598 (1),15.52 (5.974),15.52 (5.974)
+"Basic MultiFit, Dataset 1","2 params, 18 points",11.97 (1),11.97 (1),198.2 (16.56),11.97 (1)[2],11.97 (1),45.64 (3.814),71.54 (5.979),11.97 (1),11.97 (1)
+"Basic MultiFit, Dataset 2","2 params, 18 points",15.52 (5.974),15.52 (5.974),365.4 (140.7),15.52 (5.974)[2],15.52 (5.976),144.7 (55.72),2.598 (1),15.52 (5.974),15.52 (5.974)


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

This PR addresses a few bugs with the recently merged #1637:

- Adds more checks for incompatible options, as multifit problems should not currently be run with Hessians, or any cost function other than nlls ones.
- Moves the call to `multifit_init` in Fitting Benchmarking so that it is called once per minimizer, rather than once per software. `multifit_cleanup` now also clears all multifit attributes before the next minimizer is called. These functions also now work for the case where a problem has multiple sets of starting values.
- Fixes a bug in the bumps controller where incorrect x values were being passed to the solver
- Adds a helper function for more robust checking of whether a problem is a multifit one or not in `eval_r`

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1.
2.
3.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [x] The title is of a format appropriate for a line in future release notes.
- [x] I have added the appropriate tags to the PR.
- [x] My PR represents one logical piece of work.
- [x] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [x] I have added the appropriate tests to cover code that has been added.
- [x] I have updated the documentation in the relevant places to cover the changes.

