### PR TITLE
Allowed containers to be updated by workflow trigger on main

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -12,6 +12,8 @@ on:
       - 'master'
     paths:
       - 'Containers/**'
+    schedule:
+      - cron: '0 0 1 * *'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -49,7 +49,7 @@ jobs:
         tags: latest
     
     - name: Push ${{ matrix.container }} to ghcr.io
-      if: github.event_name == 'push'
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-image.outputs.image }}


### PR DESCRIPTION
<!---

Provide a short summary of this PR in the title above.
This will be used to generate release note, so please write this in the
past tense and use language that should be understandable to a potential user.

-->

## Description of work

Currently the only time the containers get updated on the github registry is when a PR is merged to master - this change means that when the build_container workflow is triggered on master, the registry also gets updated. This is useful when we want to rebuild to ensure that we have the latest versions of external software (where versions aren't pinned by the containerfile)

<!---

Describe your changes and why you're making them.

-->


## Testing Instructions

<!---

Please give any specific testing instructions to the reviewer here.

-->

1.
2.
3.

## Checklist

<!---

This checklist is mostly useful as a reminder of small things that can easily be

forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been

addressed, and remove any items that are not relevant to this PR.

-->

- [ ] The title is of a format appropriate for a line in future release notes.
- [ ] I have added the appropriate tags to the PR.
- [ ] My PR represents one logical piece of work.
- [ ] My PR fully fixes the issue linked. If new issues have been created, what are they?
- [ ] I have added the appropriate tests to cover code that has been added.
- [ ] I have updated the documentation in the relevant places to cover the changes.

